### PR TITLE
add new simulation to waveform viewer. remove old simulation in this …

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -203,10 +203,14 @@ module CommonTypes
     (*-----------------------------------------------------------------------------*)
     // Types used within waveform Simulation code, and for saved wavesim configuartion
 
-    /// Identifies a connected net
-    /// Does this tie together labelled nets? If so it should have a ComponentLabel option.
+    /// Identifies a fully connected net
+    /// This ties together labelled nets.
     /// should it include the display name(s)? this can be calculated
-    type NetGroup = { driverNet: NLTarget list; connectedNets: NLTarget list array }
+    type NetGroup = { 
+        driverComp: NetListComponent
+        driverPort: OutputPortNumber
+        driverNet: NLTarget list
+        connectedNets: NLTarget list array }
 
     /// Info saved by Wave Sim.
     /// This info is not necessarilu uptodate with deletions or additions in the Diagram.


### PR DESCRIPTION
…case for speed

This commit has new simulation controlling all output. new and old simulation in parallel under step simulator, with dev tools printout of discrepancies (= errors in old simulation).

Wave simulation is significantly faster than before due to new simulation speed.