### PR TITLE
Fix XML comments

### DIFF
--- a/src/Renderer/DrawBlock/DrawModelType.fs
+++ b/src/Renderer/DrawBlock/DrawModelType.fs
@@ -211,10 +211,11 @@ module BusWireT =
             Draggable : bool
             Mode : RoutingMode
         }
-                /// get SegmentID id for segment
-        with  member inline this.GetId() = this.Index,this.WireId
-                /// return true if segment length is 0 to within FP tolerance
-              member inline this.IsZero() = abs this.Length < XYPos.epsilon
+        with
+            /// get SegmentID id for segment
+            member inline this.GetId() = this.Index,this.WireId
+            /// return true if segment length is 0 to within FP tolerance
+            member inline this.IsZero() = abs this.Length < XYPos.epsilon
     
     /// Add absolute vertices to a segment
     type ASegment = {
@@ -222,10 +223,11 @@ module BusWireT =
             End: XYPos
             Segment: Segment
         }
-                /// get SegmentID id for segment
-        with  member inline this.GetId() = this.Segment.Index,this.Segment.WireId
-                /// return true if segment length is 0 to within FP tolerance
-              member inline this.IsZero() = abs this.Segment.Length < XYPos.epsilon
+        with
+            /// get SegmentID id for segment
+            member inline this.GetId() = this.Segment.Index,this.Segment.WireId
+            /// return true if segment length is 0 to within FP tolerance
+            member inline this.IsZero() = abs this.Segment.Length < XYPos.epsilon
 
     
     type Wire =

--- a/src/Renderer/DrawBlock/SheetUpdate.fs
+++ b/src/Renderer/DrawBlock/SheetUpdate.fs
@@ -788,13 +788,13 @@ let update (msg : Msg) (model : Model): Model*Cmd<Msg> =
                 ScrollingLastMousePos = newLastScrollingPos }, 
                 cmd
 
-    /// Zooming in increases model.Zoom. The centre of the screen will stay centred (if possible)
+    // Zooming in increases model.Zoom. The centre of the screen will stay centred (if possible)
     | KeyPress ZoomIn ->
         let oldScreenCentre = getVisibleScreenCentre model
         { model with Zoom = min Constants.maxMagnification (model.Zoom*Constants.zoomIncrement) }, 
         Cmd.ofMsg (KeepZoomCentered oldScreenCentre)
 
-    /// Zooming out decreases the model.Zoom. The centre of the screen will stay centred (if possible)
+    // Zooming out decreases the model.Zoom. The centre of the screen will stay centred (if possible)
     | KeyPress ZoomOut ->
         // get current screen edge coords
         let edge = getScreenEdgeCoords model


### PR DESCRIPTION
These comments were resulting in a 'XML comment is not placed on a valid language element.' warning. Was a bit annoying when developing to always see these show up as a problem.