### PR TITLE
Change top-level UI to bring truth tables, step, and wave simulators under one simulations tab.

### DIFF
--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -1054,10 +1054,11 @@ let viewTopMenu model messagesFunc simulateButtonFunc dispatch =
                                         dispatch <| Sheet(SheetT.DoNothing) //To update the savedsheetisoutofdate send a sheet message
                                         ) ]) [ str "Save" ] ] ]
                       Navbar.End.div []
-                          [ 
-                            Navbar.Item.div [] 
-                                [ simulateButtonFunc compIds model dispatch ] ]
-                      Navbar.End.div []
+                    // Waveform View button was moved to WaveSim subtab in Simulation tab
+                    //       [ 
+                    //         Navbar.Item.div [] 
+                    //             [ simulateButtonFunc compIds model dispatch ] ]
+                    //   Navbar.End.div []
                           [ Navbar.Item.div []
                                 [ Button.button 
                                     [ Button.OnClick(fun _ -> PopupView.viewInfoPopup dispatch) 

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -57,6 +57,7 @@ let init() = {
     // Diagram = new Draw2dWrapper()
     Sheet = fst (SheetUpdate.init())
     WaveSimulationIsOutOfDate = true
+    WaveSimulationInProgress = false
     IsLoading = false
     LastDetailedSavedState = ([],[])
     LastSimulatedCanvasState = None
@@ -68,6 +69,7 @@ let init() = {
     WaveSim = Map.empty, None
     WaveSimSheet = ""
     RightPaneTabVisible = Catalogue
+    SimSubTabVisible = StepSim
     CurrentProj = None
     Hilighted = ([], []), []
     Clipboard = [], []
@@ -109,6 +111,22 @@ let makeSelectionChangeMsg (model:Model) (dispatch: Msg -> Unit) (ev: 'a) =
 
 // -- Create View
 
+let viewSimSubTab model dispatch =
+    match model.SimSubTabVisible with
+    | StepSim -> 
+        div [ Style [Width "90%"; MarginLeft "5%"; MarginTop "15px" ] ] [
+            Heading.h4 [] [ str "Step Simulation" ]
+            SimulationView.viewSimulation model dispatch
+        ]
+    | TruthTable ->
+        div [ Style [Width "90%"; MarginLeft "5%"; MarginTop "15px" ] ] [
+            Heading.h4 [] [ str "Truth Table" ]
+            div [] [str "Placeholder for Truth Table"]
+        ]
+    | WaveSim -> 
+        div [ Style [Width "100%"; Height "calc(100% - 72px)"; MarginTop "15px" ] ]
+            ( WaveformSimulationView.viewWaveSim model dispatch )
+
 /// Display the content of the right tab.
 let private viewRightTab model dispatch =
     match model.RightPaneTabVisible with
@@ -125,13 +143,41 @@ let private viewRightTab model dispatch =
         ]
 
     | Simulation ->
-        div [ Style [Width "90%"; MarginLeft "5%"; MarginTop "15px" ] ] [
-            Heading.h4 [] [ str "Simulation" ]
-            SimulationView.viewSimulation model dispatch
-        ]
-    | WaveSim -> 
-        div [ Style [Width "100%"; Height "calc(100% - 48px)"; MarginTop "15px" ] ]
-            ( WaveformSimulationView.viewWaveSim model dispatch )
+        let subtabs = 
+            Tabs.tabs [ Tabs.IsFullWidth; Tabs.IsBoxed; Tabs.CustomClass "rightSectionTabs";
+                        Tabs.Props [Style [Margin 0] ] ]  
+                    [                 
+                    Tabs.tab // step simulation subtab
+                        [ Tabs.Tab.IsActive (model.SimSubTabVisible = StepSim) ]
+                        [ a [  OnClick (fun _ -> 
+                            if not model.WaveSimulationInProgress
+                            then
+                                dispatch <| ChangeSimSubTab StepSim ) 
+                            ] [str "Step Simulation"] ] 
+
+                    (Tabs.tab // truth table tab to display truth table for combinational logic
+                    [ Tabs.Tab.IsActive (model.SimSubTabVisible = TruthTable) ]
+                    [ a [  OnClick (fun _ -> 
+                        if not model.WaveSimulationInProgress 
+                        then
+                            dispatch <| ChangeSimSubTab TruthTable ) 
+                        ] [str "Truth Table"] ] )
+
+                    (Tabs.tab // wavesim tab
+                    [ Tabs.Tab.IsActive (model.SimSubTabVisible = WaveSim) ]
+                    [ a [  OnClick (fun _ -> 
+                        if not model.WaveSimulationInProgress
+                        then
+                            dispatch <| ChangeSimSubTab WaveSim ) 
+                        ] [str "Wave Simulation"] ])
+                    ]
+        div [ HTMLAttr.Id "RightSelection"; Style [ Height "100%" ]] 
+            [
+                //br [] // Should there be a gap between tabs and subtabs for clarity?
+                subtabs
+                viewSimSubTab model dispatch
+            ]
+
 
 /// determine whether moving the mouse drags the bar or not
 let inline setDragMode (modeIsOn:bool) (model:Model) dispatch =
@@ -147,7 +193,10 @@ let inline setDragMode (modeIsOn:bool) (model:Model) dispatch =
 
 /// Draggable vertivcal bar used to divide Wavesim window from Diagram window
 let dividerbar (model:Model) dispatch =
-    let isDraggable = model.RightPaneTabVisible = WaveSim
+    let isDraggable = 
+        model.RightPaneTabVisible = Simulation 
+        && (model.SimSubTabVisible = WaveSim 
+        || model.SimSubTabVisible = TruthTable)
     let heightAttr = 
         let rightSection = document.getElementById "RightSection"
         if (isNull rightSection) then Height "100%"
@@ -285,34 +334,24 @@ let displayView model dispatch =
                                   [ Tabs.tab // catalogue tab to add components
                                         [   Tabs.Tab.IsActive (model.RightPaneTabVisible = Catalogue) ]
                                         [ a [ OnClick (fun _ ->
-                                                if model.RightPaneTabVisible <> WaveSim 
+                                                if not model.WaveSimulationInProgress 
                                                 then 
                                                     dispatch <| ChangeRightTab Catalogue ) ] [str "Catalogue" ] ] 
                                                                   
                                     Tabs.tab // Properties tab to view/change component properties
                                         [ Tabs.Tab.IsActive (model.RightPaneTabVisible = Properties) ]                                   
                                         [ a [ OnClick (fun _ -> 
-                                                if model.RightPaneTabVisible <> WaveSim 
+                                                if not model.WaveSimulationInProgress  
                                                 then 
                                                     dispatch <| ChangeRightTab Properties )] [str "Properties"  ] ]
                                                     
-                                    (Tabs.tab // simulation tab to do combinational simulation
+                                    Tabs.tab // simulation tab to view all simulators
                                         [ Tabs.Tab.IsActive (model.RightPaneTabVisible = Simulation) ]
                                         [ a [  OnClick (fun _ -> 
-                                                if model.RightPaneTabVisible <> WaveSim 
+                                                if not model.WaveSimulationInProgress 
                                                 then
                                                     dispatch <| ChangeRightTab Simulation ) 
-                                            ] [str "Simulation"] ] )
-                            
-                                    // Optional wavesim tab. If present contains waveforms or waveform editor window
-                                    (match currWaveSimModel model with
-                                    | Some {WSViewState=WSClosed} -> 
-                                        div [] []
-                                    | _ ->
-                                        Tabs.tab // WaveSim tab - if wavesim exists
-                                            [ Tabs.Tab.IsActive (model.RightPaneTabVisible = WaveSim) ]
-                                            [ a [ OnClick (fun _ -> dispatch <| ChangeRightTab WaveSim ) ] 
-                                            [ str "WaveSim" ] ] ) 
+                                            ] [str "Simulations"] ] 
                                   ]
                         viewRightTab model dispatch  ] ] ]
 

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -17,6 +17,10 @@ type RightTab =
     | Properties
     | Catalogue
     | Simulation
+
+type SimSubTab =
+    | StepSim
+    | TruthTable
     | WaveSim
 
 type MemoryEditorData = {
@@ -271,12 +275,15 @@ type Msg =
     | SetWSModAndSheet of (WaveSimModel*string)
     | SetWSError of SimulationError option
     | AddWaveSimFile of string * WaveSimModel
+    | LockTabsToWaveSim
+    | UnlockTabsFromWaveSim
     | SetSimulationGraph of SimulationGraph  * FastSimulation
     | SetSimulationBase of NumberBase
     | IncrementSimulationClockTick of int
     | EndSimulation
     | EndWaveSim
     | ChangeRightTab of RightTab
+    | ChangeSimSubTab of SimSubTab
     | SetHighlighted of ComponentId list * ConnectionId list
     | SetSelWavesHighlighted of ConnectionId array
     | SetClipboard of CanvasState
@@ -381,6 +388,9 @@ type Model = {
     // if canvas is now different from that which is currently used by wave sim.
     WaveSimulationIsOutOfDate: bool
 
+    // if a wave simulation is being viewed, used to lock the tabs in place
+    WaveSimulationInProgress: bool
+
     // last time check for changes was made
 
     LastChangeCheckTime: float
@@ -402,6 +412,8 @@ type Model = {
     CurrentStepSimulationStep : Result<SimulationData,SimulationError> option // None if no simulation is running.
     // which of the tabbed panes is currentlky visible
     RightPaneTabVisible : RightTab
+    // which of the subtabs for the right pane simulation is visible
+    SimSubTabVisible: SimSubTab
     // components and connections which are highlighted
     Hilighted : (ComponentId list * ConnectionId list) * ConnectionId list
     // Components and connections that have been selected and copied.
@@ -689,5 +701,6 @@ let switchToWaveEditor (model:Model) dispatch =
         printf "What? Can't switch to wave editor when wave sim is closed!"
     | Some ws -> 
         dispatch <| SetWSMod {ws with WSViewState=WSViewT.WSEditorOpen}
-        dispatch <| ChangeRightTab WaveSim
+        dispatch <| ChangeRightTab Simulation
+        dispatch <| ChangeSimSubTab WaveSim
  

--- a/src/Renderer/UI/Style.fs
+++ b/src/Renderer/UI/Style.fs
@@ -22,8 +22,10 @@ let getHeaderHeight =
 let rightSectionWidth (model:Model) =
     match model.RightPaneTabVisible with
     | RightTab.Properties | RightTab.Catalogue -> rightSectionWidthS
-    | RightTab.Simulation ->  rightSectionWidthL
-    | RightTab.WaveSim -> sprintf "%dpx" model.WaveSimViewerWidth
+    | RightTab.Simulation -> 
+        match model.SimSubTabVisible with
+        | SimSubTab.StepSim -> rightSectionWidthL
+        | SimSubTab.WaveSim | SimSubTab.TruthTable -> sprintf "%dpx" model.WaveSimViewerWidth
 
 let leftSectionWidth model = Style [
     Width (sprintf "calc(100%s - %s - 10px)" "%" (rightSectionWidth model))

--- a/src/Renderer/UI/TruthTableView.fs
+++ b/src/Renderer/UI/TruthTableView.fs
@@ -1,0 +1,436 @@
+﻿//(*
+//    TruthTableView.fs
+//
+//    View for Truth Table in the right tab.
+//*)
+//
+
+module TruthTableView
+
+open Fulma
+open Fulma.Extensions.Wikiki
+open Fable.React
+open Fable.React.Props
+
+open NumberHelpers
+open Helpers
+open TimeHelpers
+open JSHelpers
+open DrawHelpers
+open DiagramStyle
+open Notifications
+open PopupView
+open MemoryEditorView
+open ModelType
+open CommonTypes
+open SimulatorTypes
+open Extractor
+open Simulator
+open TruthTableCreate
+open BusWidthInferer
+
+let getPortIdsfromConnectionId (cid: ConnectionId) (conns: Connection list) = 
+    ([],conns)
+    ||> List.fold (fun pIds c -> if c.Id = (string cid) then pIds @ [c.Source.Id;c.Target.Id] else pIds)
+    
+
+let isPortInConnections (port: Port) (conns: Connection list) =
+    (false,conns)
+    ||> List.fold (fun b c -> (port.Id = c.Source.Id || port.Id = c.Target.Id) || b )
+
+let isPortInComponents (port: Port) (comps: Component list) =
+    (false,comps)
+    ||> List.fold (fun b c -> 
+        let compPortIds = (c.InputPorts @ c.OutputPorts) |> List.map (fun p -> p.Id)
+        List.contains port.Id compPortIds || b)
+
+let filterResults results = 
+    let rec filter lst success error =
+        match lst with
+        | [] -> success,error
+        | (Ok c)::tl -> filter tl (success @ [c]) error
+        | (Error e)::tl -> filter tl success (error @ [e])
+    filter results [] []
+        
+let correctCanvasState (selectedCanvasState: CanvasState) (wholeCanvasState: CanvasState) =
+    let components,connections = selectedCanvasState
+    let dummyInputPort = {
+        Id = "DummyIn"
+        PortNumber = None
+        PortType = PortType.Input
+        HostId = "DummyIn_Host"
+    }
+    let dummyOutputPort = {
+        Id = "DummyOut"
+        PortNumber = None
+        PortType = PortType.Output
+        HostId = "DummyOut_Host"
+    }
+
+    let connectionWidths = 
+        match BusWidthInferer.inferConnectionsWidth wholeCanvasState with
+        | Ok cw -> cw
+        | Error _ -> failwithf "what? WidthInferrer failed to infer widths from whole canvas during TT Calculation"
+
+    let portWidths =
+        Map.toList connectionWidths
+        |> List.fold (fun acc (cid,widthopt) ->
+            let pIdEntries = 
+                getPortIdsfromConnectionId cid (snd wholeCanvasState)
+                |> List.map (fun pId -> (pId,widthopt))
+            acc @ pIdEntries) []
+        |> Map.ofList
+
+    let getPortWidth pId =
+        match Map.tryFind pId portWidths with
+        | Some(Some w) -> Some w
+        | Some(None) -> failwithf "what? WidthInferrer did not infer a width for a port"
+        | None -> None
+
+    let inferIOLabel (port: Port) =
+        let hostComponent =
+            components 
+            |> List.filter (fun c -> port.HostId = c.Id)
+            |> function 
+                | [comp] -> comp
+                | [] -> failwithf "what? Port HostId does not match any ComponentIds in model"
+                | _ -> failwithf "what? Port HostId matches multiple ComponentIds in model"
+        let portOnComponent =
+            match port.PortNumber with
+            | Some n -> port
+            | None ->
+                components
+                |> List.collect (fun c -> List.append c.InputPorts c.OutputPorts)
+                |> List.filter (fun cp -> port.Id = cp.Id)
+                |> function
+                    | [p] -> p
+                    | _ -> failwithf "what? connection port does not map to a component port"
+                
+        match portOnComponent.PortNumber, port.PortType with
+        | None,_ -> failwithf "what? no PortNumber. A connection port was probably passed to inferIOLabel"
+        | Some pn, PortType.Input -> 
+            match Symbol.portDecName hostComponent with
+            | ([],_) -> hostComponent.Label + "_IN" + (string pn)
+            | (lst,_) -> 
+                if pn >= lst.Length then
+                    failwithf "what? input PortNumber is greater than number of input port names on component"
+                else
+                    hostComponent.Label + "_" + lst[pn]
+        | Some pn, PortType.Output ->
+            match Symbol.portDecName hostComponent with
+            | (_,[]) -> hostComponent.Label + "_OUT" + (string pn)
+            | (_,lst) ->
+                if pn >= lst.Length then
+                    failwithf "what? output PortNumber is greater than number of output port names on component"
+                else
+                    hostComponent.Label + "_" + lst[pn]
+
+
+    let addExtraConnections (comps: Component list,conns: Connection list) =
+        comps,
+        (conns,comps)
+        ||> List.fold (fun acc comp -> 
+            let extraInputConns = 
+                comp.InputPorts
+                |> List.filter (fun p -> not (isPortInConnections p conns))
+                |> List.map (fun p -> 
+                    {
+                        Id = JSHelpers.uuid()
+                        Source = dummyOutputPort
+                        Target = {p with PortNumber = None}
+                        Vertices = [(0.0,0.0)] // Irrelevant as we never draw this connection
+                    })
+            let extraOutputConns =
+                comp.OutputPorts
+                |> List.filter (fun p -> not (isPortInConnections p conns))
+                |> List.map (fun p -> 
+                    {
+                        Id = JSHelpers.uuid()
+                        Source = {p with PortNumber = None}
+                        Target = dummyInputPort
+                        Vertices = [(0.0,0.0)] // Irrelevant as we never draw this connection
+                    })
+            acc @ extraInputConns @ extraOutputConns)
+
+    let addExtraIOs (comps: Component list,conns: Connection list) =
+        // let mutable inputCount = 0
+        // let mutable outputCount = 0
+        let compsOk : Result<Component,SimulationError> list = List.map (fun c -> Ok c) comps
+
+        (compsOk,conns)
+        ||> List.mapFold (fun acc con ->
+            if  not (isPortInComponents con.Source comps) && not (isPortInComponents con.Target comps) then
+                let error = {
+                    Msg = "Selected logic includes a wire connected to no components."
+                    InDependency = None
+                    ComponentsAffected = []
+                    ConnectionsAffected = [ConnectionId(con.Id)]}
+                Error error,acc
+            else if not (isPortInComponents con.Source comps) then
+                match getPortWidth con.Target.Id with
+                | Some pw ->
+                    let newId = JSHelpers.uuid()
+                    let newLabel = inferIOLabel con.Target
+                    // inputCount <- inputCount + 1
+                    let newPort = {
+                        Id = JSHelpers.uuid()
+                        PortNumber = Some 0
+                        PortType = PortType.Output
+                        HostId = newId}
+                    let extraInput = {
+                        Id = newId
+                        Type = Input(pw)
+                        Label = newLabel
+                        InputPorts = []
+                        OutputPorts = [newPort]
+                        X = 0
+                        Y = 0
+                        H = 0
+                        W = 0}
+                    Ok {con with Source = {newPort with PortNumber = None}}, acc @ [Ok extraInput]
+                | None ->
+                    let error = {
+                        Msg = "Could not infer the width for an input into the selected logic."
+                        InDependency = None
+                        ComponentsAffected = [ComponentId(con.Target.HostId)]
+                        ConnectionsAffected = []
+                    }
+                    Ok con, acc @ [Error error]
+            else if not (isPortInComponents con.Target comps) then
+                match getPortWidth con.Source.Id with
+                | Some pw ->
+                    let newId = JSHelpers.uuid()
+                    let newLabel = inferIOLabel con.Source
+                    //outputCount <- outputCount + 1
+                    let newPort = {
+                        Id = JSHelpers.uuid()
+                        PortNumber = Some 0
+                        PortType = PortType.Input
+                        HostId = newId}
+                    let extraOutput = {
+                        Id = newId
+                        Type = Output(pw)
+                        Label = newLabel
+                        InputPorts = [newPort]
+                        OutputPorts = []
+                        X = 0
+                        Y = 0
+                        H = 0
+                        W = 0}
+                    Ok {con with Target = {newPort with PortNumber = None}}, acc @ [Ok extraOutput]
+                | None ->
+                    let error = {
+                        Msg = "Could not infer the width for an output produced by the selected logic."
+                        InDependency = None
+                        ComponentsAffected = [ComponentId(con.Source.HostId)]
+                        ConnectionsAffected = []
+                    }
+                    Ok con, acc @ [Error error]
+            else
+                Ok con,acc)
+        |> (fun (a,b) -> (b,a))
+    
+    let checkCanvasWasCorrected (compsRes: Result<Component,SimulationError> list,connsRes: Result<Connection,SimulationError> list) =
+        let comps,compErrors = filterResults compsRes
+        let conns,connErrors = filterResults connsRes
+
+        match compErrors,connErrors with
+        | [],[] -> Ok (comps,conns)
+        | e::tl,_ -> Error e
+        | _,e::tl -> Error e
+        
+
+    (components,connections)
+    |> addExtraConnections
+    |> addExtraIOs
+    |> checkCanvasWasCorrected
+    
+let makeSimDataSelected model : (Result<SimulationData,SimulationError> * CanvasState) option =
+    let (selComponents,selConnections) = model.Sheet.GetSelectedCanvasState
+    let wholeCanvas = model.Sheet.GetCanvasState()
+    let selOtherComponents =
+        ([],selComponents)
+        ||> List.fold (fun acc comp ->
+            match comp.Type with
+            | Custom cc -> acc @ [cc.Name]
+            | _ -> acc)
+
+    match selComponents, selConnections, model.CurrentProj with
+    | _,_,None -> None
+    | [],[],_ -> None
+    | [],_,_ -> Some <| (Error {
+        Msg = "Only connections selected. Please select a combination of connections and components."
+        InDependency = None
+        ComponentsAffected = []
+        ConnectionsAffected =[] }, (selComponents,selConnections))
+    | selComps,selConns,Some project ->
+        let selLoadedComponents =
+            project.LoadedComponents
+            |> List.filter (fun comp ->
+                comp.Name <> project.OpenFileName
+                && List.contains comp.Name selOtherComponents)
+        match correctCanvasState (selComps,selConns) wholeCanvas with
+        | Error e -> Some (Error e, (selComps,selConns))
+        | Ok (correctComps,correctConns) ->
+            match CanvasStateAnalyser.analyseState (correctComps,correctConns) selLoadedComponents with
+            | Some e -> Some (Error e,(correctComps,correctConns))
+            | None ->
+                Some (prepareSimulation project.OpenFileName (correctComps,correctConns) selLoadedComponents , (correctComps,correctConns))
+
+let tableAsList (table: TruthTable): TruthTableRow list =
+    table.TableMap
+    |> Map.toList
+    |> List.map (fun (lhs,rhs) -> List.append lhs rhs)
+
+let viewCellAsHeading (cell: TruthTableCell) = 
+    let (_,label,_) = cell.IO
+    let headingText = string label
+    th [ ] [str headingText]
+
+let viewCellAsData (cell: TruthTableCell) =
+    match cell.Data with 
+    | Bits [] -> failwithf "what? Empty WireData in TruthTable"
+    | Bits [bit] -> td [] [str <| bitToString bit]
+    | Bits bits ->
+        let width = List.length bits
+        let value = viewFilledNum width Hex <| convertWireDataToInt bits
+        td [] [str value]
+    | Algebra a -> td [] [str <| a]
+    | DC -> td [] [str <| "X"]
+
+let viewRowAsData (row: TruthTableRow) =
+    let cells = 
+        row
+        |> List.map viewCellAsData
+        |> List.toSeq
+    tr [] cells
+        
+let viewTruthTableError simError =
+    let error = 
+        match simError.InDependency with
+        | None ->
+            div [] [
+                str simError.Msg
+                br []
+                str <| "Please fix the error and retry."
+            ]
+        | Some dep ->
+            div [] [
+                str <| "Error found in dependency \"" + dep + "\":"
+                br []
+                str simError.Msg
+                br []
+                str <| "Please fix the error in the dependency and retry."
+            ]
+    div [] [
+        Heading.h5 [ Heading.Props [ Style [ MarginTop "15px" ] ] ] [ str "Errors" ]
+        error
+    ]
+    
+let viewTruthTableData (table: TruthTable) =
+    if table.TableMap.IsEmpty then // Should never be matched
+        div [] [str "No Truth Table to Display"]
+    else
+        let TTasList = tableAsList table
+        let headings =
+            TTasList.Head
+            |> List.map viewCellAsHeading
+            |> List.toSeq
+        let body =
+            TTasList
+            |> List.map viewRowAsData
+            |> List.toSeq
+            
+
+        div [] [
+            Table.table [
+                Table.IsBordered
+                Table.IsFullWidth
+                Table.IsStriped
+                Table.IsHoverable] 
+                [ 
+                    thead [] [tr [] headings]
+                    tbody [] body
+                ]
+        ]
+
+let viewTruthTable model dispatch =
+    let generateTruthTable simRes =
+        match simRes with 
+        | Some (Ok sd,_) -> 
+            sd
+            |> truthTable
+            |> Ok
+            |> GenerateTruthTable
+            |> dispatch
+        | Some (Error e,_) ->
+            Error e
+            |> GenerateTruthTable
+            |> dispatch
+        | None -> ()
+
+    match model.CurrentTruthTable with
+    | None ->
+        let wholeSimRes = SimulationView.makeSimData model
+        let wholeButtonColor, wholeButtonText, wholeButtonAction =
+            match wholeSimRes with
+            | None -> IColor.IsWhite, "", (fun _ -> ())
+            | Some (Ok sd,_) -> 
+                if sd.IsSynchronous = false then 
+                    IColor.IsSuccess, "Generate Truth Table", generateTruthTable
+                else 
+                    IColor.IsInfo, "Combinational Only!", (fun _ -> ())
+            | Some (Error _,_) -> IColor.IsWarning, "See Problems", generateTruthTable
+        div [] [
+            str "Generate Truth Tables for combinational logic using this tab."
+            br[]
+            hr[]
+            Heading.h5 [] [str "Truth Table for whole sheet"]
+            br []
+            Button.button
+                [ 
+                    Button.Color wholeButtonColor; 
+                    Button.OnClick (fun _ -> wholeButtonAction  wholeSimRes ) ; 
+                ]
+                [ str wholeButtonText ]
+            hr[]
+
+            let selSimRes = makeSimDataSelected model
+            let selButtonColor, selButtonText, selButtonAction =
+                match selSimRes with
+                | None -> IColor.IsWhite, "", (fun _ -> ())
+                | Some (Ok sd,_) -> 
+                    if sd.IsSynchronous = false then 
+                        IColor.IsSuccess, "Generate Truth Table", generateTruthTable
+                    else 
+                        IColor.IsInfo, "Combinational Only!", (fun _ -> ())
+                | Some (Error _,_) -> IColor.IsWarning, "See Problems", generateTruthTable 
+            Heading.h5 [] [str "Truth Table for selected logic"]
+            br []
+            Button.button
+                [ 
+                    Button.Color selButtonColor; 
+                    Button.OnClick (fun _ -> selButtonAction selSimRes ) ; 
+                ]
+                [ str selButtonText ]
+            hr[]
+        ]
+    | Some tableopt ->
+        let closeTruthTable _ =
+            dispatch CloseTruthTable
+        let body = 
+            match tableopt with
+            | Error e -> viewTruthTableError e
+            | Ok table -> viewTruthTableData table
+        div [] [
+            Button.button
+                [ Button.Color IsDanger; Button.OnClick closeTruthTable ]
+                [ str "Close Truth Table" ]
+            br []; br []
+            str "The Truth Table generator uses the diagram as it was at the moment of
+                 pressing the \"Generate Truth Table\" button."
+            hr []
+            body
+            br []
+            hr []
+            ]

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -385,6 +385,10 @@ let update (msg : Msg) oldModel =
         { model with WaveSim = fst model.WaveSim, err}, Cmd.none
     | AddWaveSimFile (fileName, wSMod') ->
         { model with WaveSim = Map.add fileName wSMod' (fst model.WaveSim), snd model.WaveSim}, Cmd.none
+    | LockTabsToWaveSim -> 
+        {model with WaveSimulationInProgress = true}, Cmd.none
+    | UnlockTabsFromWaveSim ->
+        {model with WaveSimulationInProgress = false}, Cmd.none
     | SetSimulationGraph (graph, fastSim) ->
         let simData = getSimulationDataOrFail model "SetSimulationGraph"
         { model with CurrentStepSimulationStep = { simData with Graph = graph ; FastSim = fastSim} |> Ok |> Some }, Cmd.none
@@ -405,8 +409,16 @@ let update (msg : Msg) oldModel =
         | Properties -> Cmd.batch <| editCmds
         | Catalogue -> Cmd.batch  <| editCmds
         | Simulation -> Cmd.batch <| editCmds
-        | WaveSim -> Cmd.ofMsg (Sheet (SheetT.SetWaveSimMode true))
- 
+        //| TruthTable -> Cmd.batch <| editCmds
+        //| WaveSim -> Cmd.ofMsg (Sheet (Sheet.SetWaveSimMode true))
+    | ChangeSimSubTab subTab ->
+        let inferMsg = JSDiagramMsg <| InferWidths()
+        let editCmds = [inferMsg; ClosePropertiesNotification] |> List.map Cmd.ofMsg
+        { model with SimSubTabVisible = subTab},
+        match subTab with
+        | StepSim -> Cmd.batch <| editCmds
+        | TruthTable -> Cmd.batch <| editCmds
+        | WaveSim -> Cmd.batch <| editCmds
     | SetHighlighted (componentIds, connectionIds) ->
         let sModel, sCmd = SheetUpdate.update (SheetT.ColourSelection (componentIds, connectionIds, HighLightColor.Red)) model.Sheet
         {model with Sheet = sModel}, Cmd.map Sheet sCmd

--- a/src/Renderer/UI/WaveformSimulationView.fs
+++ b/src/Renderer/UI/WaveformSimulationView.fs
@@ -563,8 +563,7 @@ let private waveEditorTickBoxRows model wsModel (dispatch: Msg -> unit) =
 /// ReactElement of the bottom section of the WaveAdder.
 /// Contains tick-boxes for NetGroups
 let private waveEditorTickBoxesAndNames (model: Model) wSModel (dispatch: Msg -> unit) =
-    div [ Style [ Position PositionOptions.Absolute
-                  CSSProp.Top "300px" ] ]
+    div [ Style [ Position PositionOptions.Relative; CSSProp.Top "20px" ] ]
         [ table []
                 [ tbody [] 
                         (Array.append [| waveEditorSelectAllRow model wSModel dispatch |] 
@@ -576,8 +575,8 @@ let private waveEditorButtons (model: Model) (wSModel:WaveSimModel) dispatch =
     let closeWaveSimButtonAction _ev =
         dispatch <| StartUICmd CloseWaveSim
         dispatch <| SetWSMod {wSModel with InitWaveSimGraph=None; WSViewState=WSClosed; WSTransition = None}
-        dispatch <| ChangeRightTab Catalogue
         dispatch <| SetWaveSimIsOutOfDate true
+        dispatch <| UnlockTabsFromWaveSim
         dispatch <| Sheet (SheetT.ResetSelection)
         dispatch <| Sheet (SheetT.SetWaveSimMode false)
         dispatch ClosePropertiesNotification
@@ -755,7 +754,8 @@ let startWaveSim compIds rState (simData: SimulatorTypes.SimulationData) model (
     dispatch <| SetLastSimulatedCanvasState (Some rState) 
     dispatch <| SetWaveSimIsOutOfDate false
     inputWarningPopup simData dispatch
-    dispatch <| ChangeRightTab WaveSim
+    dispatch <| Sheet (SheetT.SetWaveSimMode true)
+    dispatch <| LockTabsToWaveSim
     dispatch FinishUICmd
 
 //------------------------------------------------------------------------------------------------------------
@@ -773,9 +773,7 @@ let WaveformButtonFunc compIds model dispatch =
                 initFileWS model dispatch
             | None -> ()
             Button.button 
-                [ Button.OnClick(fun _ -> 
-                    dispatch <| ChangeRightTab WaveSim)
-                ]
+                [ Button.OnClick(fun _ -> ())]
         | Some wSModel ->
             match wSModel.WSViewState, model.WaveSimulationIsOutOfDate, SimulationView.makeSimData model with
             | WSClosed, _, Some (Ok simData, rState)
@@ -807,7 +805,6 @@ let WaveformButtonFunc compIds model dispatch =
                     [   Button.Color IsWarning
                         Button.OnClick(fun _ ->
                           dispatch <| SetWSError (Some err) 
-                          dispatch <| ChangeRightTab WaveSim
                           SimulationView.SetSimErrorFeedback err model dispatch) 
                     ]
             | x,y,z ->
@@ -815,10 +812,8 @@ let WaveformButtonFunc compIds model dispatch =
                 Button.button 
                     [ Button.Color IsSuccess
                       Button.IsLight
-                      Button.OnClick(fun _ -> 
-                          dispatch <| ChangeRightTab WaveSim) 
-                    ]
-    simulationButton [ str "Waveforms >>" ]
+                      Button.OnClick(fun _ -> ())]
+    simulationButton [ str "View Waveforms" ]
 
 /// This is the top-level view function entry for the wave simulator after it has been set up.
 /// ReactElement list of the whole waveform simulator
@@ -837,8 +832,20 @@ let viewWaveSim (model: Model) dispatch =
         | WSViewerOpen, _  ->         // otherwise display waveforms 
             waveformsView compIds model netList wSModel dispatch  
         | _, prog  -> 
-            printfn "ViewWaveSim should not be called when WaveSimEditorOpen =%A, inProgress = %A" wSModel.WSViewState prog
-            [ div [] [] ]
+            let compIds = getComponentIds model
+            let button = WaveformButtonFunc compIds model dispatch
+            [ div
+                [ Style
+                    [   Width "90%"
+                        MarginLeft "5%"
+                        MarginTop "15px" ] ]
+            [   Heading.h4 [] [ str "Waveform Simulation" ]
+                str "Use this tab to view Waveforms for sequential logic."
+                str "Test combinational logic by closing this simulator and using Step Simulator tab."
+                hr []
+                br []
+                button
+            ]]
 
     // Set the current simulation error message
     | Some _, Some simError ->


### PR DESCRIPTION
This PR contains my changes to the top-level UI. The Step Simulator, Truth Tables, and Waveform Simulator are all grouped as sub-tabs under a main Simulations tab in the right section. The Waveforms button has been removed. This means that all simulation related activity is accessed in a consistent manner.

Opening this PR  separately to the rest of my FYP work (which will be merged after 22nd June) so that Jason can merge his work, as his work uses these changes. The multiple commits which implemented this change have been rebased into one single commit.