### PR TITLE
Fix bug where name row did not match value and wave rows

### DIFF
--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -476,12 +476,15 @@ let waveSimButtonsBar (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactEle
 // let moveWave (wsModel: WaveSimModel) (direction: bool) (dispatch: Msg -> unit) : unit =
 //     ()
 
-/// Create label of waveform name for each selected wave
+/// Create label of waveform name for each selected wave.
+/// Note that this is generated after calling selectedWaves.
+/// Any changes to this function must also be made to valueRows
+/// and waveRows, as the order of the waves matters here. This is
+/// because the wave viewer is comprised of three columns of many
+/// rows, rather than many rows of three columns.
 let nameRows (wsModel: WaveSimModel) : ReactElement list =
-    wsModel.SelectedWaves
-    |> List.map (fun driver ->
-        label [ labelStyle ] [ str wsModel.AllWaves[driver].DisplayName ]
-    )
+    selectedWaves wsModel
+    |> List.map (fun wave -> label [ labelStyle ] [ str wave.DisplayName ])
 
 /// Create column of waveform names
 let namesColumn wsModel : ReactElement =
@@ -491,6 +494,11 @@ let namesColumn wsModel : ReactElement =
         (List.concat [ topRow; rows ])
 
 /// Create label of waveform value for each selected wave at a given clk cycle.
+/// Note that this is generated after calling selectedWaves.
+/// Any changes to this function must also be made to nameRows
+/// and waveRows, as the order of the waves matters here. This is
+/// because the wave viewer is comprised of three columns of many
+/// rows, rather than many rows of three columns.
 let valueRows (wsModel: WaveSimModel) = 
     selectedWaves wsModel
     |> List.map (getWaveValue wsModel.CurrClkCycle)
@@ -533,6 +541,11 @@ let clkCycleNumberRow (wsModel: WaveSimModel) =
 
 /// Generate a column of waveforms corresponding to selected waves.
 let waveformColumn (wsModel: WaveSimModel) : ReactElement =
+    /// Note that this is generated after calling selectedWaves.
+    /// Any changes to this function must also be made to nameRows
+    /// and valueRows, as the order of the waves matters here. This is
+    /// because the wave viewer is comprised of three columns of many
+    /// rows, rather than many rows of three columns.
     let waveRows : ReactElement list =
         selectedWaves wsModel
         |> List.map (fun wave ->

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -77,9 +77,7 @@ let singleWaveWidth wsModel = 30.0 * wsModel.ZoomLevel
 let button options func label = Button.button (List.append options [ Button.OnClick func ]) [ label ]
 
 let selectedWaves (wsModel: WaveSimModel) : Wave list =
-    Map.filter (fun name _ -> List.contains name wsModel.SelectedWaves) wsModel.AllWaves
-    |> Map.values
-    |> Seq.toList
+    List.map (fun index -> wsModel.AllWaves[index]) wsModel.SelectedWaves
 
 let pointsToString (points: XYPos list) : string =
     List.fold (fun str (point: XYPos) ->


### PR DESCRIPTION
After changing selected waves, the name row did not match the value and wave rows.

This is because the name row was generated differently to the value and wave rows. They are now generated in the same way (by calling `selectedWaves`)