### PR TITLE
Improve UI for wave viewer

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -614,9 +614,7 @@ module CommonTypes
     /// The wavesim code processing this will not fail if non-existent nets are referenced.
     type SavedWaveInfo = {
         SelectedWaves: WaveIndexT list option
-        ShownCycles: int option
         Radix: NumberBase option
-        ZoomLevel: float option
         ZoomLevelIndex: int option
         WaveformColumnWidth: int option
 

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -17,6 +17,9 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Browser.Dom
 
+module Constants =
+    let dividerBarWidth = 10
+
 //------------------Buttons overlaid on Draw2D Diagram----------------------------------//
 //--------------------------------------------------------------------------------------//
 
@@ -190,7 +193,7 @@ let dividerbar (model:Model) dispatch =
         if isDraggable then [
             BackgroundColor "grey"
             Cursor "ew-resize" 
-            Width "10px"
+            Width Constants.dividerBarWidth
 
         ] else [
             BackgroundColor "lightgray"
@@ -230,10 +233,14 @@ let displayView model dispatch =
         if wsModel.State = WSOpen then
             dispatch <| SetViewerWidth w
 
-            let waveColWidth = w - Constants.namesColMinWidth - Constants.valuesColMinWidth
+            /// Unsure of why there needs to be 2* in front of dividerBarWidth... but it seems to work.
+            let otherDivWidths = Constants.leftMargin + Constants.rightMargin + 2 * Constants.dividerBarWidth
+
+            let waveColWidth = w - otherDivWidths - Constants.namesColWidth - Constants.valuesColWidth
             let wholeCycles = waveColWidth / int (singleWaveWidth wsModel)
             let wholeCycleWidth = wholeCycles * int (singleWaveWidth wsModel)
-            let viewerWidth = Constants.namesColMinWidth + Constants.valuesColMinWidth + wholeCycleWidth
+
+            let viewerWidth = Constants.namesColWidth + Constants.valuesColWidth + wholeCycleWidth + otherDivWidths
 
             let wsModel = {
                 wsModel with

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -158,7 +158,6 @@ type WaveSimModel = {
     CurrClkCycle: int
     ClkCycleBoxIsEmpty: bool
     Radix: NumberBase
-    ZoomLevel: float
     ZoomLevelIndex: int
     WaveformColumnWidth: int
 }
@@ -173,11 +172,10 @@ let initWSModel : WaveSimModel = {
     AllWaves = Map.empty
     SelectedWaves = List.empty
     StartCycle = 0
-    ShownCycles = 7
+    ShownCycles = 6
     CurrClkCycle = 0
     ClkCycleBoxIsEmpty = false
     Radix = Hex
-    ZoomLevel = 1.5
     ZoomLevelIndex = 9
     WaveformColumnWidth = initialWaveformColWidth
 }
@@ -444,9 +442,7 @@ let getComponentIds (model: Model) =
 let getSavedWaveInfo (wsModel: WaveSimModel) : SavedWaveInfo =
     {
         SelectedWaves = Some wsModel.SelectedWaves
-        ShownCycles = Some wsModel.ShownCycles
         Radix = Some wsModel.Radix
-        ZoomLevel = Some wsModel.ZoomLevel
         ZoomLevelIndex = Some wsModel.ZoomLevelIndex
         WaveformColumnWidth = Some wsModel.WaveformColumnWidth
 
@@ -466,9 +462,7 @@ let loadWSModelFromSavedWaveInfo (swInfo: SavedWaveInfo) : WaveSimModel =
     {
         initWSModel with
             SelectedWaves = Option.defaultValue initWSModel.SelectedWaves swInfo.SelectedWaves
-            ShownCycles = Option.defaultValue initWSModel.ShownCycles swInfo.ShownCycles
             Radix = Option.defaultValue initWSModel.Radix swInfo.Radix
-            ZoomLevel = Option.defaultValue initWSModel.ZoomLevel swInfo.ZoomLevel
             ZoomLevelIndex = Option.defaultValue initWSModel.ZoomLevelIndex swInfo.ZoomLevelIndex
             WaveformColumnWidth = Option.defaultValue initWSModel.WaveformColumnWidth swInfo.WaveformColumnWidth
     }

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -57,6 +57,8 @@ module Constants =
         0.25; 0.33; 0.5; 0.67; 0.75; 0.8; 0.9; 1.0; 1.1; 1.5; 1.75; 2.0; 2.50; 3.0; 4.0; 5.0;
     |]
 
+    let baseWidth = 30.0
+
 let getWSModel model : WaveSimModel =
     Map.tryFind model.WaveSimSheet model.WaveSim
     |> function
@@ -67,12 +69,16 @@ let getWSModel model : WaveSimModel =
             // printf "Sheet %A not found in model" model.WaveSimSheet
             initWSModel
 
-let viewBoxMinX m = string (float m.StartCycle * m.ZoomLevel)
-let viewBoxWidth m = string (float m.ShownCycles * m.ZoomLevel)
+let zoomLevel m = Constants.zoomLevels[m.ZoomLevelIndex]
 
-let endCycle wsModel = wsModel.StartCycle + wsModel.ShownCycles - 1
+let singleWaveWidth wsModel = Constants.baseWidth * (zoomLevel wsModel)
 
-let singleWaveWidth wsModel = 30.0 * wsModel.ZoomLevel
+let shownCycles m = int <| float m.WaveformColumnWidth / singleWaveWidth m
+
+let viewBoxMinX m = string (float m.StartCycle * zoomLevel m)
+let viewBoxWidth m = string (float (shownCycles m) * zoomLevel m)
+
+let endCycle wsModel = wsModel.StartCycle + (shownCycles wsModel) - 1
 
 let button options func label = Button.button (List.append options [ Button.OnClick func ]) [ label ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -13,9 +13,11 @@ open Fable.React.Props
 // let busLabelTextSize = 0.6 // multiplied by signal height
 
 module Constants =
-    let namesColMinWidth = 250
-    let valuesColMinWidth = 100
+    let namesColWidth = 200
+    let valuesColWidth = 100
 
+    let leftMargin = 50
+    let rightMargin = 50
 
     let rowHeight = 30
     let clkLineWidth = 0.0125
@@ -259,7 +261,7 @@ let waveSimColumn = [
 
 let namesColumnStyle = Style (
     (waveSimColumn) @ [
-        MinWidth "215px"
+        MinWidth Constants.namesColWidth
         Float FloatOptions.Left
         BorderRight borderProperties
         GridColumnStart 1
@@ -268,7 +270,7 @@ let namesColumnStyle = Style (
 
 let valuesColumnStyle = Style (
     (waveSimColumn) @ [
-        MinWidth "75px"
+        MinWidth Constants.valuesColWidth
         Float FloatOptions.Right
         BorderLeft borderProperties
         GridColumnStart 3
@@ -302,8 +304,8 @@ let showWaveformsStyle = Style [
 ]
 
 let waveSelectionPaneStyle = Style [
-    Width "90%"
-    MarginLeft "5%"
+    MarginLeft Constants.leftMargin
+    MarginRight Constants.rightMargin
     MarginTop "15px"
 ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -23,9 +23,6 @@ module Constants =
     let clkLineWidth = 0.0125
     let lineThickness : float = 0.025
 
-
-let endCycle wsModel = wsModel.StartCycle + wsModel.ShownCycles - 1
-
 let topRowStyle = Style [
     Height Constants.rowHeight
     BorderBottom "2px solid rgb(219,219,219)"
@@ -318,7 +315,7 @@ let clkCycleText m i : IProp list =
     [
         SVGAttr.FontSize "3.5%"
         SVGAttr.TextAnchor "middle"
-        X (m.ZoomLevel * (float i + 0.5))
+        X (zoomLevel m * (float i + 0.5))
         Y 0.65
     ]
 
@@ -329,7 +326,7 @@ let clkCycleSVGStyle = Style [
 
 let waveformColumnRowProps m : IProp list = [
     SVGAttr.Height Constants.rowHeight
-    SVGAttr.Width (float m.ShownCycles * 30.0 * m.ZoomLevel)
+    SVGAttr.Width (float (shownCycles m) * singleWaveWidth m)
     // min-x, min-y, width, height
     ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string Constants.viewBoxHeight)
     PreserveAspectRatio "none"
@@ -358,15 +355,15 @@ let clkCycleHighlightSVG m count =
             GridRowStart 1
         ]
         SVGAttr.Height (string ((count + 1) * Constants.rowHeight) + "px")
-        SVGAttr.Width (float m.ShownCycles * 30.0 * m.ZoomLevel)
+        SVGAttr.Width (float (shownCycles m) * singleWaveWidth m)
         SVGAttr.Fill "rgb(230,230,230)"
         SVGAttr.Opacity 0.4
         ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string (Constants.viewBoxHeight * float (count + 1)))
     ] [
         rect [
-            SVGAttr.Width (m.ZoomLevel)
+            SVGAttr.Width (zoomLevel m)
             SVGAttr.Height "100%"
-            X (float m.CurrClkCycle * m.ZoomLevel)
+            X (float m.CurrClkCycle * zoomLevel m)
         ] []
     ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -16,7 +16,8 @@ module Constants =
     let namesColMinWidth = 250
     let valuesColMinWidth = 100
 
-    let rowHeight = "30px"
+
+    let rowHeight = 30
     let clkLineWidth = 0.0125
     let lineThickness : float = 0.025
 
@@ -97,7 +98,7 @@ let selectWavesStyle = Style [
 ]
 
 let closeWaveSimButtonStyle = Style [
-    Height "30px"
+    Height Constants.rowHeight
     FontSize "16px"
     Float FloatOptions.Left
     Position PositionOptions.Relative
@@ -147,7 +148,7 @@ let zoomInSVG =
 let clkCycleButtonStyle = Style [
     Float FloatOptions.Right
     Position PositionOptions.Relative
-    Height "30px"
+    Height Constants.rowHeight
     TextAlign TextAlignOptions.Center
     Display DisplayOptions.InlineBlock
     FontSize "13px"
@@ -160,7 +161,7 @@ let clkCycleInputStyle = Style [
     Float FloatOptions.Left
     TextAlign TextAlignOptions.Center
     Width "40px"
-    Height "30px"
+    Height Constants.rowHeight
     Display DisplayOptions.InlineBlock
     FontSize "13px"
     Resize "vertical"
@@ -178,7 +179,7 @@ let clkCycleInputProps : IHTMLProp list = [
 
 let clkCycleBut = [
     Margin 0
-    Height "30px"
+    Height Constants.rowHeight
     Padding 0
     Width "30px"
     Position PositionOptions.Relative
@@ -214,7 +215,7 @@ let waveSimButtonsBarStyle = Style [ Height "45px" ]
 let upDownDivStyle = Style [
     Width "100%"
     Position PositionOptions.Relative
-    Height "30px"
+    Height Constants.rowHeight
     Float FloatOptions.Left
 ]
 
@@ -249,7 +250,7 @@ let waveSimColumn = [
     Width "100%"
     BorderTop borderProperties
     Display DisplayOptions.Grid
-    GridAutoRows "30px" 
+    GridAutoRows Constants.rowHeight
     FontSize "12px"
     OverflowX OverflowOptions.Scroll
     WhiteSpace WhiteSpaceOptions.Nowrap
@@ -283,7 +284,7 @@ let waveRowsStyle width = Style [
     OverflowX OverflowOptions.Hidden
     Display DisplayOptions.Grid
     FontSize "12px"
-    GridAutoRows "30px"
+    GridAutoRows Constants.rowHeight
     BorderTop borderProperties
     Width width
     GridColumnStart 1
@@ -325,7 +326,7 @@ let clkCycleSVGStyle = Style [
 ]
 
 let waveformColumnRowProps m : IProp list = [
-    SVGAttr.Height "30px"
+    SVGAttr.Height Constants.rowHeight
     SVGAttr.Width (float m.ShownCycles * 30.0 * m.ZoomLevel)
     // min-x, min-y, width, height
     ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string Constants.viewBoxHeight)
@@ -354,7 +355,7 @@ let clkCycleHighlightSVG m count =
             GridColumnStart 1
             GridRowStart 1
         ]
-        SVGAttr.Height (string ((count + 1)* 30) + "px")
+        SVGAttr.Height (string ((count + 1) * Constants.rowHeight) + "px")
         SVGAttr.Width (float m.ShownCycles * 30.0 * m.ZoomLevel)
         SVGAttr.Fill "rgb(230,230,230)"
         SVGAttr.Opacity 0.4
@@ -371,18 +372,18 @@ let clkCycleHighlightSVG m count =
 let radixTabProps : IHTMLProp list = [
     Style [
         Width "35px"
-        Height "30px"
+        Height Constants.rowHeight
     ]
 ]
 
 let radixTabAStyle = Style [
     Padding "0 0 0 0"
-    Height "30px"
+    Height Constants.rowHeight
 ]
 
 let radixTabsStyle = Style [
     Width "140px"
-    Height "30px"
+    Height Constants.rowHeight
     FontSize "80%"
     Float FloatOptions.Right
     Margin "0 10px 0 10px"


### PR DESCRIPTION
This PR changes the way the width of each column is generated. This should reduce the frequency of the values column being out of sight due to the wave viewer being too wide.

This PR also changes ZoomLevel and ShownCycles so they are calculated from other values in the model, rather than being saved. This reduces the likelihood of bugs occurring.