### PR TITLE
Add support for Input components to be simulated with non-zero values

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -310,7 +310,7 @@ module CommonTypes
 
     // Types instantiating objects in the Digital extension.
     type ComponentType =
-        | Input of BusWidth: int | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
+        | Input of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
         | BusCompare of BusWidth: int * CompareValue: uint32
         | BusSelection of OutputWidth: int * OutputLSBit: int
         | Constant of Width: int * ConstValue: int64 

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -310,7 +310,7 @@ module CommonTypes
 
     // Types instantiating objects in the Digital extension.
     type ComponentType =
-        | Input of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
+        | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
         | BusCompare of BusWidth: int * CompareValue: uint32
         | BusSelection of OutputWidth: int * OutputLSBit: int
         | Constant of Width: int * ConstValue: int64 

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -310,6 +310,7 @@ module CommonTypes
 
     // Types instantiating objects in the Digital extension.
     type ComponentType =
+        | Input of BusWidth: int // Legacy component: to be deleted
         | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
         | BusCompare of BusWidth: int * CompareValue: uint32
         | BusSelection of OutputWidth: int * OutputLSBit: int

--- a/src/Renderer/Common/WidthInferer.fs
+++ b/src/Renderer/Common/WidthInferer.fs
@@ -161,7 +161,7 @@ let private calculateOutputPortsWidth
     match comp.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input width | Constant1(width,_,_) | Constant(width,_)->
+    | Input (width, _) | Constant1(width,_,_) | Constant(width,_)->
         // Expects no inputs, and has an outgoing wire of the given width.
         assertInputsSize inputConnectionsWidth 0 comp
         Ok <| Map.empty.Add (getOutputPortId comp 0, width)

--- a/src/Renderer/Common/WidthInferer.fs
+++ b/src/Renderer/Common/WidthInferer.fs
@@ -161,6 +161,7 @@ let private calculateOutputPortsWidth
     match comp.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input components should never occur"
     | Input1 (width, _) | Constant1(width,_,_) | Constant(width,_)->
         // Expects no inputs, and has an outgoing wire of the given width.
         assertInputsSize inputConnectionsWidth 0 comp

--- a/src/Renderer/Common/WidthInferer.fs
+++ b/src/Renderer/Common/WidthInferer.fs
@@ -161,7 +161,7 @@ let private calculateOutputPortsWidth
     match comp.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input (width, _) | Constant1(width,_,_) | Constant(width,_)->
+    | Input1 (width, _) | Constant1(width,_,_) | Constant(width,_)->
         // Expects no inputs, and has an outgoing wire of the given width.
         assertInputsSize inputConnectionsWidth 0 comp
         Ok <| Map.empty.Add (getOutputPortId comp 0, width)
@@ -589,7 +589,7 @@ let private initialiseConnectionsWidth connections : ConnectionsWidth =
     |> Map.ofList
 
 let private getAllInputNodes components : Component list =
-    components |> List.filter (fun comp -> match comp.Type with | Input _ -> true | _ -> false)
+    components |> List.filter (fun comp -> match comp.Type with | Input1 _ -> true | _ -> false)
 
 /// For each connected input port, map the connection that is connected to it.
 /// Fail if there are multiple connections connected to the same input port.

--- a/src/Renderer/DrawBlock/DrawModelType.fs
+++ b/src/Renderer/DrawBlock/DrawModelType.fs
@@ -173,6 +173,7 @@ module SymbolT =
         | ErrorSymbols of errorIds: ComponentId list * selectIds: ComponentId list * isDragAndDrop: bool
         | ChangeNumberOfBits of compId:ComponentId * NewBits:int 
         | ChangeLsb of compId: ComponentId * NewBits:int64 
+        | ChangeInputValue of compId: ComponentId * newVal: int
         | ChangeConstant of compId: ComponentId * NewBits:int64 * NewText:string
         | ResetModel // For Issie Integration
         | LoadComponents of  LoadedComponent list * Component list // For Issie Integration

--- a/src/Renderer/DrawBlock/PopupDrawingView.fs
+++ b/src/Renderer/DrawBlock/PopupDrawingView.fs
@@ -81,7 +81,7 @@ let formatLabelAsBus (width:int) (text:string) =
 let formatLabelFromType compType (text:string) =
     let text' = extractLabelBase text
     match compType with
-    | Input 1 | Output 1 -> text'
+    | Input (1, _) | Output 1 -> text'
     //| Input width | Output width -> sprintf "%s(%d:%d)" text' (width-1) 0
     | _ -> text'
 

--- a/src/Renderer/DrawBlock/PopupDrawingView.fs
+++ b/src/Renderer/DrawBlock/PopupDrawingView.fs
@@ -81,8 +81,7 @@ let formatLabelAsBus (width:int) (text:string) =
 let formatLabelFromType compType (text:string) =
     let text' = extractLabelBase text
     match compType with
-    | Input (1, _) | Output 1 -> text'
-    //| Input width | Output width -> sprintf "%s(%d:%d)" text' (width-1) 0
+    | Input1 (1, _) | Output 1 -> text'
     | _ -> text'
 
 

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -611,6 +611,7 @@ let emptySnap: SnapXY =
 /// snap to each other.
 let symbolMatch (symbol: SymbolT.Symbol) =
     match symbol.Component.Type with
+    | Input _ // legacy component - to be deleted
     | Input1 _ | Output _| IOLabel -> 
         Input1 (0, None)
 

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -611,8 +611,8 @@ let emptySnap: SnapXY =
 /// snap to each other.
 let symbolMatch (symbol: SymbolT.Symbol) =
     match symbol.Component.Type with
-    | Input _ | Output _| IOLabel -> 
-        Input (0, None)
+    | Input1 _ | Output _| IOLabel -> 
+        Input1 (0, None)
 
     | BusCompare _
     | BusSelection _ -> 

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -93,6 +93,9 @@ module SheetInterface =
         member this.ChangeLSB (dispatch: Dispatch<Msg>) (compId: ComponentId) (lsb: int64) =
             dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeLsb (compId, lsb) ) ) )
 
+        member this.ChangeInputValue (dispatch: Dispatch<Msg>) (compId: ComponentId) (newVal: int) =
+            dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeInputValue (compId, newVal))))
+
         /// Return Some string if Sheet / BusWire / Symbol has a notification, if there is none then return None
         member this.GetNotifications =
             // Currently only BusWire has notifications
@@ -144,8 +147,6 @@ module SheetInterface =
         /// Update the memory of component specified by connId at location addr with data value
         member this.WriteMemoryLine dispatch connId addr value =
             dispatch <| (Wire (BusWireT.Symbol (SymbolT.WriteMemoryLine (connId, addr, value))))
-
-
 
 //-------------------------------------------------------------------------------------------------//
 // ------------------------------------------- Helper Functions ------------------------------------------- //
@@ -611,7 +612,7 @@ let emptySnap: SnapXY =
 let symbolMatch (symbol: SymbolT.Symbol) =
     match symbol.Component.Type with
     | Input _ | Output _| IOLabel -> 
-        Input 0
+        Input (0, None)
 
     | BusCompare _
     | BusSelection _ -> 

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -522,7 +522,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
         failwithf "What? Legacy RAM component types should never occur"
     | And | Or | Nand | Nor | Xor | Xnor ->  (2 , 1, 1.5*gS , 1.5*gS) 
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
-    | ComponentType.Input (a) -> ( 0 , 1, gS ,  2.*gS)                
+    | Input _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
     | ComponentType.Viewer a -> (  1 , 0, gS ,  gS) 
     | ComponentType.IOLabel  ->(  1 , 1, gS/2. ,  gS) 
@@ -1010,7 +1010,7 @@ let drawSymbol (symbol:Symbol) =
             addText {X = w/2. + xOffset; Y = h/1.5 + yOffset}  dialogVal align "normal" fontSize
         | BusCompare (_,y) -> 
             (addText {X = w/2.-2.; Y = h/2.7-1.} ("=" + NumberHelpers.hex(int y)) "middle" "bold" "10px")
-        | Input x | Output x-> 
+        | Input (x, _) | Output x-> 
             (addText {X = w/2.; Y = h/2.7} (busTitleAndBits "" x) "middle" "normal" "12px")
         | Viewer (x) -> 
             (addText {X = w/2.; Y = h/2.7 - 1.25} (busTitleAndBits "" x) "middle" "normal" "9px")

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -522,7 +522,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
         failwithf "What? Legacy RAM component types should never occur"
     | And | Or | Nand | Nor | Xor | Xnor ->  (2 , 1, 1.5*gS , 1.5*gS) 
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
-    | Input _ -> ( 0 , 1, gS ,  2.*gS)                
+    | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
     | ComponentType.Viewer a -> (  1 , 0, gS ,  gS) 
     | ComponentType.IOLabel  ->(  1 , 1, gS/2. ,  gS) 
@@ -914,7 +914,7 @@ let drawSymbol (symbol:Symbol) =
         let toString = Array.fold (fun x (pos:XYPos) -> x + (sprintf $" {pos.X},{pos.Y}")) "" 
         let originalPoints =
             match comp.Type with
-            | Input _ -> 
+            | Input1 _ -> 
                 [|{X=0;Y=0};{X=0;Y=H};{X=W*4./5.;Y=H};{X=W;Y=H/2.};{X=W*0.8;Y=0}|] 
             | Output _ -> 
                 [|{X=W/5.;Y=0};{X=0;Y=H/2.};{X=W/5.;Y=H};{X=W;Y=H};{X=W;Y=0}|]
@@ -1010,7 +1010,7 @@ let drawSymbol (symbol:Symbol) =
             addText {X = w/2. + xOffset; Y = h/1.5 + yOffset}  dialogVal align "normal" fontSize
         | BusCompare (_,y) -> 
             (addText {X = w/2.-2.; Y = h/2.7-1.} ("=" + NumberHelpers.hex(int y)) "middle" "bold" "10px")
-        | Input (x, _) | Output x-> 
+        | Input1 (x, _) | Output x-> 
             (addText {X = w/2.; Y = h/2.7} (busTitleAndBits "" x) "middle" "normal" "12px")
         | Viewer (x) -> 
             (addText {X = w/2.; Y = h/2.7 - 1.25} (busTitleAndBits "" x) "middle" "normal" "9px")

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -520,6 +520,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     match compType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | And | Or | Nand | Nor | Xor | Xnor ->  (2 , 1, 1.5*gS , 1.5*gS) 
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
@@ -914,6 +915,7 @@ let drawSymbol (symbol:Symbol) =
         let toString = Array.fold (fun x (pos:XYPos) -> x + (sprintf $" {pos.X},{pos.Y}")) "" 
         let originalPoints =
             match comp.Type with
+            | Input _ // legacy component: to be deleted
             | Input1 _ -> 
                 [|{X=0;Y=0};{X=0;Y=H};{X=W*4./5.;Y=H};{X=W;Y=H/2.};{X=W*0.8;Y=0}|] 
             | Output _ -> 
@@ -1010,6 +1012,7 @@ let drawSymbol (symbol:Symbol) =
             addText {X = w/2. + xOffset; Y = h/1.5 + yOffset}  dialogVal align "normal" fontSize
         | BusCompare (_,y) -> 
             (addText {X = w/2.-2.; Y = h/2.7-1.} ("=" + NumberHelpers.hex(int y)) "middle" "bold" "10px")
+        | Input x // legacy component type: to be deleted
         | Input1 (x, _) | Output x-> 
             (addText {X = w/2.; Y = h/2.7} (busTitleAndBits "" x) "middle" "normal" "12px")
         | Viewer (x) -> 

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -215,6 +215,7 @@ let changeNumberOfBitsf (symModel:Model) (compId:ComponentId) (newBits : int) =
 
     let newcompotype = 
         match symbol.Component.Type with
+        | Input _ -> failwithf "Legacy Input component types should never occur"
         | Input1 (_, defaultVal) -> Input1 (newBits, defaultVal)
         | Output _ -> Output newBits
         | Viewer _ -> Viewer newBits

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -215,7 +215,7 @@ let changeNumberOfBitsf (symModel:Model) (compId:ComponentId) (newBits : int) =
 
     let newcompotype = 
         match symbol.Component.Type with
-        | Input (_, defaultVal) -> Input (newBits, defaultVal)
+        | Input1 (_, defaultVal) -> Input1 (newBits, defaultVal)
         | Output _ -> Output newBits
         | Viewer _ -> Viewer newBits
         | NbitsAdder _ -> NbitsAdder newBits
@@ -249,10 +249,10 @@ let changeInputValue (symModel: Model) (compId: ComponentId) (newVal: int) =
     let symbol = Map.find compId symModel.Symbols
     let width =
         match symbol.Component.Type with
-        | Input (width, _) -> width
+        | Input1 (width, _) -> width
         | _ -> failwithf "changeInputValue should only be called for Input components"
 
-    let newComp = {symbol.Component with Type = Input (width, Some newVal)}
+    let newComp = {symbol.Component with Type = Input1 (width, Some newVal)}
     {symbol with Component = newComp}
 
 /// Updates the value of a constant1 component and returns the updated symbol

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -196,7 +196,7 @@ let getOrderedCompLabels compType ((comps,_): CanvasState) =
     |> List.collect (fun comp -> 
         let sortKey = comp.Y,comp.X
         match comp.Type, compType with 
-        | Input (n, defaultVal), Input _ -> [sortKey,(comp.Label, n)]
+        | Input1 (n, defaultVal), Input1 _ -> [sortKey,(comp.Label, n)]
         | Output n, Output _ -> [sortKey, (comp.Label,n)] 
         | _ -> [])
     |> List.sortBy fst
@@ -207,7 +207,7 @@ let getOrderedCompLabels compType ((comps,_): CanvasState) =
 /// Form is inputs,outputs
 let parseDiagramSignature canvasState
         : (string * int) list * (string * int) list =
-    let inputs = getOrderedCompLabels (Input (0, None)) canvasState
+    let inputs = getOrderedCompLabels (Input1 (0, None)) canvasState
     let outputs = getOrderedCompLabels (Output 0) canvasState
     inputs, outputs
 

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -196,7 +196,7 @@ let getOrderedCompLabels compType ((comps,_): CanvasState) =
     |> List.collect (fun comp -> 
         let sortKey = comp.Y,comp.X
         match comp.Type, compType with 
-        | Input n, Input _ -> [sortKey,(comp.Label, n)]
+        | Input (n, defaultVal), Input _ -> [sortKey,(comp.Label, n)]
         | Output n, Output _ -> [sortKey, (comp.Label,n)] 
         | _ -> [])
     |> List.sortBy fst
@@ -207,7 +207,7 @@ let getOrderedCompLabels compType ((comps,_): CanvasState) =
 /// Form is inputs,outputs
 let parseDiagramSignature canvasState
         : (string * int) list * (string * int) list =
-    let inputs = getOrderedCompLabels (Input 0) canvasState
+    let inputs = getOrderedCompLabels (Input (0, None)) canvasState
     let outputs = getOrderedCompLabels (Output 0) canvasState
     inputs, outputs
 

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -484,6 +484,7 @@ let getLatestComp (comp: Component) =
     | ROM mem -> {comp with Type = ROM1 (updateMem mem)}
     | AsyncROM mem -> { comp with Type = AsyncROM1 (updateMem mem)}
     | Constant(width,cVal) -> {comp with Type = Constant1(width, cVal, $"%d{cVal}")}
+    | Input width -> { comp with Type = Input1 (width, None)}
     | _ -> comp
 
 

--- a/src/Renderer/Simulator/Builder.fs
+++ b/src/Renderer/Simulator/Builder.fs
@@ -108,6 +108,7 @@ let private getDefaultState compType =
     match compType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | Input1 _ | Output _ | IOLabel | BusSelection _ | BusCompare _ | Not | And | Or | Xor | Nand | Nor | Xnor | Mux2 | Mux4 | Mux8 | Decode4
     | Demux2 | Demux4 | Demux8 | NbitsAdder _ |NbitsXor _ | Custom _ | MergeWires | SplitWire _ | ROM1 _  | Viewer _ -> NoState
     | Constant1 _ | Constant _ -> NoState 

--- a/src/Renderer/Simulator/Builder.fs
+++ b/src/Renderer/Simulator/Builder.fs
@@ -108,7 +108,7 @@ let private getDefaultState compType =
     match compType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input _ | Output _ | IOLabel | BusSelection _ | BusCompare _ | Not | And | Or | Xor | Nand | Nor | Xnor | Mux2 | Mux4 | Mux8 | Decode4
+    | Input1 _ | Output _ | IOLabel | BusSelection _ | BusCompare _ | Not | And | Or | Xor | Nand | Nor | Xnor | Mux2 | Mux4 | Mux8 | Decode4
     | Demux2 | Demux4 | Demux8 | NbitsAdder _ |NbitsXor _ | Custom _ | MergeWires | SplitWire _ | ROM1 _  | Viewer _ -> NoState
     | Constant1 _ | Constant _ -> NoState 
     | AsyncROM1 _ -> NoState

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -334,7 +334,7 @@ let private checkIOLabels (canvasState : CanvasState) : SimulationError option =
     let components, _ = canvasState
     let inputs =
         components
-        |> List.filter (fun comp -> match comp.Type with | Input _ -> true | _ -> false)
+        |> List.filter (fun comp -> match comp.Type with | Input1 _ -> true | _ -> false)
     let outputs =
         components
         |> List.filter (fun comp -> match comp.Type with | Output _ -> true | _ -> false)

--- a/src/Renderer/Simulator/FastCreate.fs
+++ b/src/Renderer/Simulator/FastCreate.fs
@@ -60,7 +60,7 @@ let getPortNumbers (sc: SimulationComponent) =
         match sc.Type with
         | Constant1 _ | Constant _ ->
             0,1
-        | Input _
+        | Input1 _
         | Output _
         | Viewer _ 
         | BusSelection _
@@ -114,7 +114,7 @@ let getOutputWidths (sc: SimulationComponent) (wa: int option array) =
     match sc.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input (w, _)
+    | Input1 (w, _)
     | Output w
     | Viewer w
     | Register w
@@ -178,7 +178,7 @@ let createFastComponent (numSteps: int) (sComp: SimulationComponent) (accessPath
         let dat =
             match accessPath, sComp.Type with
             // top-level input needs special inputs because they can't be calculated
-            | [], Input (width, defaultVal) -> List.replicate width Zero
+            | [], Input1 (width, defaultVal) -> List.replicate width Zero
             | _ -> []
 
         [| 0 .. inPortNum - 1 |]
@@ -248,7 +248,7 @@ let extendFastComponent (numSteps: int) (fc: FastComponent) =
         // Input inputs at top level are a special case not mapped to outputs.
         // They must be separately extended.
         match fc.FType, fc.AccessPath with
-        | Input _, [] -> extendArray fc.InputLinks[0] fc.InputLinks[0].Step[oldNumSteps - 1]
+        | Input1 _, [] -> extendArray fc.InputLinks[0] fc.InputLinks[0].Step[oldNumSteps - 1]
         | _ -> ()
 
         [| 0 .. outPortNum - 1 |]
@@ -314,7 +314,7 @@ let rec private createFlattenedSimulation (ap: ComponentId list) (graph: Simulat
                         (fun comp ->
                             (comp.Label,
                                 match comp.Type with
-                                | Input (n, _) -> n
+                                | Input1 (n, _) -> n
                                 | Output n -> n
                                 | _ -> -1),
                             comp.Id)

--- a/src/Renderer/Simulator/FastCreate.fs
+++ b/src/Renderer/Simulator/FastCreate.fs
@@ -114,7 +114,7 @@ let getOutputWidths (sc: SimulationComponent) (wa: int option array) =
     match sc.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input w
+    | Input (w, _)
     | Output w
     | Viewer w
     | Register w
@@ -178,7 +178,7 @@ let createFastComponent (numSteps: int) (sComp: SimulationComponent) (accessPath
         let dat =
             match accessPath, sComp.Type with
             // top-level input needs special inputs because they can't be calculated
-            | [], Input width -> List.replicate width Zero
+            | [], Input (width, defaultVal) -> List.replicate width Zero
             | _ -> []
 
         [| 0 .. inPortNum - 1 |]
@@ -314,7 +314,7 @@ let rec private createFlattenedSimulation (ap: ComponentId list) (graph: Simulat
                         (fun comp ->
                             (comp.Label,
                                 match comp.Type with
-                                | Input n -> n
+                                | Input (n, _) -> n
                                 | Output n -> n
                                 | _ -> -1),
                             comp.Id)

--- a/src/Renderer/Simulator/FastCreate.fs
+++ b/src/Renderer/Simulator/FastCreate.fs
@@ -101,6 +101,7 @@ let getPortNumbers (sc: SimulationComponent) =
         | Not | And | Or | Xor | Nand | Nor | Xnor -> 2,1
         | Custom _ -> failwithf "Custom components should not occur in fast simulation"
         | AsyncROM _ | RAM _ | ROM _ -> failwithf "legacy component type is not supported"
+        | Input _ -> failwithf "Legacy Input component types should never occur"
 
     ins, outs
 
@@ -114,6 +115,7 @@ let getOutputWidths (sc: SimulationComponent) (wa: int option array) =
     match sc.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | Input1 (w, _)
     | Output w
     | Viewer w

--- a/src/Renderer/Simulator/FastReduce.fs
+++ b/src/Renderer/Simulator/FastReduce.fs
@@ -199,7 +199,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     match componentType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input width ->
+    | Input (width, _) ->
         if comp.Active then
             let bits = ins 0
             //printfn "Got input 0 = %A Links=<%A> len=%d" bits comp.InputLinks comp.InputLinks.Length

--- a/src/Renderer/Simulator/FastReduce.fs
+++ b/src/Renderer/Simulator/FastReduce.fs
@@ -199,7 +199,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     match componentType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input (width, _) ->
+    | Input1 (width, _) ->
         if comp.Active then
             let bits = ins 0
             //printfn "Got input 0 = %A Links=<%A> len=%d" bits comp.InputLinks comp.InputLinks.Length

--- a/src/Renderer/Simulator/FastReduce.fs
+++ b/src/Renderer/Simulator/FastReduce.fs
@@ -199,6 +199,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     match componentType with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | Input1 (width, _) ->
         if comp.Active then
             let bits = ins 0

--- a/src/Renderer/Simulator/FastRun.fs
+++ b/src/Renderer/Simulator/FastRun.fs
@@ -96,10 +96,20 @@ let private orderCombinationalComponents (numSteps: int) (fs: FastSimulation) : 
         propagateEval fc
 
     let initInput (fc: FastComponent) =
+        let inputVal : uint32 =
+            match fc.FType with
+            | Input (w, defaultVal) ->
+                match defaultVal with
+                | Some defaultVal -> defaultVal
+                | None -> 0
+            | _ ->
+                printf "non-input type component in initInput"
+                0
+            |> uint32
         //printfn "Init input..."
         fc.InputLinks[0].Step
         |> Array.iteri
-            (fun i _ -> fc.InputLinks[0].Step[i] <- (convertIntToFastData (Option.defaultValue 1 fc.OutputWidth[0]) 0u))
+            (fun i _ -> fc.InputLinks[0].Step[i] <- (convertIntToFastData (Option.defaultValue 1 fc.OutputWidth[0]) inputVal))
         //printfn "Initialised input: %A" fc.InputLinks
         fastReduce fs.MaxArraySize 0 false fc
         fc.Touched <- true

--- a/src/Renderer/Simulator/FastRun.fs
+++ b/src/Renderer/Simulator/FastRun.fs
@@ -23,7 +23,7 @@ let private isValidData (fd: FastData) = fd <> emptyFastData
 /// True if the component is combinational
 let inline isComb (comp: FastComponent) =
     match comp.FType with
-    | Input _ when comp.AccessPath = [] -> false
+    | Input1 _ when comp.AccessPath = [] -> false
     | AsyncRAM1 _ -> true
     | ct when couldBeSynchronousComponent ct -> false
     | _ -> true
@@ -98,7 +98,7 @@ let private orderCombinationalComponents (numSteps: int) (fs: FastSimulation) : 
     let initInput (fc: FastComponent) =
         let inputVal : uint32 =
             match fc.FType with
-            | Input (w, defaultVal) ->
+            | Input1 (w, defaultVal) ->
                 match defaultVal with
                 | Some defaultVal -> defaultVal
                 | None -> 0

--- a/src/Renderer/Simulator/NumberHelpers.fs
+++ b/src/Renderer/Simulator/NumberHelpers.fs
@@ -202,7 +202,7 @@ let private countBits (num : int64) : int =
     (String.length <| bin64 num) - 2
 
 /// Check a number is formed by at most <width> bits.
-let rec private checkWidth (width : int) (num : int64) : string option =
+let rec checkWidth (width : int) (num : int64) : string option =
     if num < 0L then
         checkWidth width <| (-num) - 1L
     else    

--- a/src/Renderer/Simulator/Runner.fs
+++ b/src/Renderer/Simulator/Runner.fs
@@ -216,7 +216,7 @@ let checkPropagation (graph : SimulationGraph) : SimulationGraph =
             let comp = graph[cid]
             match comp.Type, couldBeSynchronousComponent comp.Type with
             | _,true -> graph
-            | Input _,_ | Constant1 _, _-> graph
+            | Input1 _,_ | Constant1 _, _-> graph
             | _,false -> 
                 let reducerInput = {
                     Inputs = comp.Inputs
@@ -366,7 +366,7 @@ let getSimulationIOs
         : SimulationIO list * SimulationIO list =
     (([], []), components) ||> List.fold (fun (inputs, outputs) comp ->
         match comp.Type with
-        | Input (w, _)  -> ((ComponentId comp.Id, ComponentLabel comp.Label, w) :: inputs, outputs)
+        | Input1 (w, _)  -> ((ComponentId comp.Id, ComponentLabel comp.Label, w) :: inputs, outputs)
         | Output w -> (inputs, (ComponentId comp.Id, ComponentLabel comp.Label, w) :: outputs)
         | _ -> (inputs, outputs)
     )
@@ -378,7 +378,7 @@ let getSimulationIOsFromGraph
         : SimulationIO list * SimulationIO list =
     (([], []), graph) ||> Map.fold (fun (inputs, outputs) compId comp ->
         match comp.Type with
-        | Input (w, _)  -> ((comp.Id, comp.Label, w) :: inputs, outputs)
+        | Input1 (w, _)  -> ((comp.Id, comp.Label, w) :: inputs, outputs)
         | Output w -> (inputs, (comp.Id, comp.Label, w) :: outputs)
         | _ -> (inputs, outputs)
     )

--- a/src/Renderer/Simulator/Runner.fs
+++ b/src/Renderer/Simulator/Runner.fs
@@ -366,7 +366,7 @@ let getSimulationIOs
         : SimulationIO list * SimulationIO list =
     (([], []), components) ||> List.fold (fun (inputs, outputs) comp ->
         match comp.Type with
-        | Input w  -> ((ComponentId comp.Id, ComponentLabel comp.Label, w) :: inputs, outputs)
+        | Input (w, _)  -> ((ComponentId comp.Id, ComponentLabel comp.Label, w) :: inputs, outputs)
         | Output w -> (inputs, (ComponentId comp.Id, ComponentLabel comp.Label, w) :: outputs)
         | _ -> (inputs, outputs)
     )
@@ -378,7 +378,7 @@ let getSimulationIOsFromGraph
         : SimulationIO list * SimulationIO list =
     (([], []), graph) ||> Map.fold (fun (inputs, outputs) compId comp ->
         match comp.Type with
-        | Input w  -> ((comp.Id, comp.Label, w) :: inputs, outputs)
+        | Input (w, _)  -> ((comp.Id, comp.Label, w) :: inputs, outputs)
         | Output w -> (inputs, (comp.Id, comp.Label, w) :: outputs)
         | _ -> (inputs, outputs)
     )

--- a/src/Renderer/Simulator/SynchronousUtils.fs
+++ b/src/Renderer/Simulator/SynchronousUtils.fs
@@ -15,7 +15,7 @@ open SimulatorTypes
 let couldBeSynchronousComponent compType : bool =
     match compType with
     | DFF | DFFE | Register _ | RegisterE _ | ROM1 _ | RAM1 _ | AsyncRAM1 _ | Custom _ -> true // We have to assume custom components are clocked as they may be.
-    | Input _ | Output _ | IOLabel | Constant1 _ | BusSelection _ | BusCompare _ | MergeWires | SplitWire _ | Not | And | Or | Xor
+    | Input1 _ | Output _ | IOLabel | Constant1 _ | BusSelection _ | BusCompare _ | MergeWires | SplitWire _ | Not | And | Or | Xor
     | Nand | Nor | Xnor | Mux2 | Mux4 | Mux8 | Demux2 | Demux4 | Demux8 | NbitsAdder _ | NbitsXor _ | Decode4 | AsyncROM1 _ | Viewer _ -> false
     | _ -> failwithf $"Legacy components {compType} should never be read!"
 
@@ -39,14 +39,14 @@ let rec hasSynchronousComponents graph : bool =
             match comp.Type with
             | DFF | DFFE | Register _ | RegisterE _ | ROM1 _ | RAM1 _ | AsyncRAM1 _ -> true
             | Custom _ -> hasSynchronousComponents <| Option.get comp.CustomSimulationGraph
-            | Input _ | Output _ | IOLabel | BusSelection _ | BusCompare _ | MergeWires | SplitWire _ | Not | And | Or
+            | Input1 _ | Output _ | IOLabel | BusSelection _ | BusCompare _ | MergeWires | SplitWire _ | Not | And | Or
             | Xor | Nand | Nor | Xnor | Mux2 | Mux4 | Mux8 | Demux2 | Demux4 | Demux8 | NbitsAdder _ | NbitsXor _ | Decode4 | AsyncROM1 _ | Constant1 _ | Viewer _ -> false
             | _ -> failwithf $"legacy components should never be read {comp.Type}"
         )
     |> Map.tryPick (fun compId isSync -> if isSync then Some () else None)
     |> function | Some _ -> true | None -> false
 
-let isInput = function | Input _ -> true | _ -> false
+let isInput = function | Input1 _ -> true | _ -> false
 let isOutput = function | Output _ -> true | _ -> false
 let isCustom = function | Custom _ -> true | _ -> false
 let isIOLabel = function | IOLabel _ -> true | _ -> false

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -355,7 +355,7 @@ let fastOutputDefinition (vType:VMode) (fc: FastComponent) (opn: OutputPortNumbe
     | Output n, [] -> $"output {vDef};\n"
     | DFF, _
     | DFFE, _ -> $"reg {vDef} = 1'b0;\n"
-    | Input (n, _), [] ->
+    | Input1 (n, _), [] ->
         match vType with 
         | ForSynthesis -> $"input {vDef};\n"
         | ForSimulation -> $"reg {vDef} = {getZeros n};\n"
@@ -398,12 +398,12 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
 
     match fc.FType with
     | Viewer _ -> ""
-    | Input _ when fc.AccessPath = [] 
+    | Input1 _ when fc.AccessPath = [] 
         -> failwithf "What? cannot call getVerilogComponent to find code for global Input"
     | Output _
     | Viewer _
     | IOLabel _
-    | Input _ -> sprintf $"assign %s{outs 0} = %s{ins 0};\n"
+    | Input1 _ -> sprintf $"assign %s{outs 0} = %s{ins 0};\n"
 
     | Not -> sprintf "assign %s = ! %s;\n" (outs 0) (ins 0)
     | And
@@ -516,7 +516,7 @@ let getMainHeader (vType:VMode) (fs: FastSimulation) =
             match fc.FType, fc.AccessPath with
             | Output _, [] -> // NB - inputs are assigned zero in synthesis and not included in module header
                 [| fc.VerilogOutputName[0] |]
-            | Input _, [] when vType = ForSynthesis -> [| fc.VerilogOutputName[0] |]
+            | Input1 _, [] when vType = ForSynthesis -> [| fc.VerilogOutputName[0] |]
             | _ -> [||])
     |> Array.append (match vType with | ForSynthesis -> [|"clk"|] | ForSimulation -> [||])
     |> String.concat ",\n\t"

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -355,7 +355,7 @@ let fastOutputDefinition (vType:VMode) (fc: FastComponent) (opn: OutputPortNumbe
     | Output n, [] -> $"output {vDef};\n"
     | DFF, _
     | DFFE, _ -> $"reg {vDef} = 1'b0;\n"
-    | Input n, [] ->
+    | Input (n, _), [] ->
         match vType with 
         | ForSynthesis -> $"input {vDef};\n"
         | ForSimulation -> $"reg {vDef} = {getZeros n};\n"

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -355,6 +355,7 @@ let fastOutputDefinition (vType:VMode) (fc: FastComponent) (opn: OutputPortNumbe
     | Output n, [] -> $"output {vDef};\n"
     | DFF, _
     | DFFE, _ -> $"reg {vDef} = 1'b0;\n"
+    | Input _, _ -> failwithf "Legacy Input component types should never occur"
     | Input1 (n, _), [] ->
         match vType with 
         | ForSynthesis -> $"input {vDef};\n"
@@ -504,6 +505,7 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
     | Custom _ -> failwithf "What? custom components cannot exist in fast Simulation data structure"
     | AsyncROM _ | RAM _ | ROM _ -> 
         failwithf $"Invalid legacy component type '{fc.FType}'"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
 
 
 /// return the header of the main verilog module with hardware inputs and outputs in header.

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -38,7 +38,7 @@ let private makeCustom styles model dispatch (loadedComponent: LoadedComponent) 
     menuItem styles loadedComponent.Name (fun _ ->
         let custom = Custom {
             Name = loadedComponent.Name
-            InputLabels = FilesIO.getOrderedCompLabels (Input (0, None)) canvas
+            InputLabels = FilesIO.getOrderedCompLabels (Input1 (0, None)) canvas
             OutputLabels = FilesIO.getOrderedCompLabels (Output 0) canvas
         }
         
@@ -392,7 +392,7 @@ let viewCatalogue model dispatch =
                 // TODO
                     makeMenuGroup
                         "Input / Output"
-                        [ catTip1 "Input"  (fun _ -> createInputPopup "input" Input model dispatch) "Input connection to current sheet: one or more bits"
+                        [ catTip1 "Input"  (fun _ -> createInputPopup "input" Input1 model dispatch) "Input connection to current sheet: one or more bits"
                           catTip1 "Output" (fun _ -> createIOPopup true "output" Output model dispatch) "Output connection from current sheet: one or more bits"
                           catTip1 "Viewer" (fun _ -> createIOPopup true "viewer" Viewer model dispatch) "Viewer to expose value in simulation: works in subsheets"
                           catTip1 "Constant" (fun _ -> createConstantPopup model dispatch) "Define a one or more bit constant value, \

--- a/src/Renderer/UI/CustomCompPorts.fs
+++ b/src/Renderer/UI/CustomCompPorts.fs
@@ -484,7 +484,7 @@ let checkCanvasStateIsOk (model:Model) =
         let comps,conns = ldc.CanvasState
         let ioNames =
             comps
-            |> List.filter (fun comp -> match comp.Type with | Input _ | Output _ -> true | _ -> false)
+            |> List.filter (fun comp -> match comp.Type with | Input1 _ | Output _ -> true | _ -> false)
             |> List.map (fun comp -> comp.Label)
         ioNames.Length = (List.distinct ioNames).Length
         )

--- a/src/Renderer/UI/PopupView.fs
+++ b/src/Renderer/UI/PopupView.fs
@@ -77,8 +77,7 @@ let formatLabelAsBus (width:int) (text:string) =
 let formatLabelFromType compType (text:string) =
     let text' = extractLabelBase text
     match compType with
-    | Input (1, _) | Output 1 -> text'
-    //| Input width | Output width -> sprintf "%s(%d:%d)" text' (width-1) 0
+    | Input1 (1, _) | Output 1 -> text'
     | _ -> text'
 
 

--- a/src/Renderer/UI/PopupView.fs
+++ b/src/Renderer/UI/PopupView.fs
@@ -77,7 +77,7 @@ let formatLabelAsBus (width:int) (text:string) =
 let formatLabelFromType compType (text:string) =
     let text' = extractLabelBase text
     match compType with
-    | Input 1 | Output 1 -> text'
+    | Input (1, _) | Output 1 -> text'
     //| Input width | Output width -> sprintf "%s(%d:%d)" text' (width-1) 0
     | _ -> text'
 
@@ -293,6 +293,46 @@ let dialogPopupBodyTwoInts (beforeInt1,beforeInt2) (intDefault1,intDefault2) (wi
                     setPopupTwoInts(SecondInt, Some text) n)
             ]
         ]
+
+/// Create the body of a dialog Popup with text and two ints.
+let dialogPopupBodyTextAndTwoInts (beforeText, textPlaceholder) (beforeInt1,beforeInt2) (intDefault1,intDefault2) dispatch =
+
+    let setPopupTwoInts (whichInt:IntMode, optText) =
+        fun (n:int64) -> (Some n, whichInt, optText) |> SetPopupDialogTwoInts |> dispatch
+
+    setPopupTwoInts (FirstInt,None) (int64 intDefault1)
+    setPopupTwoInts (SecondInt, None) intDefault2 
+
+    fun (dialogData : PopupDialogData) ->
+        div [] [
+            beforeText dialogData
+            br []
+            Input.text [
+                Input.Props [OnPaste preventDefault; AutoFocus true; SpellCheck false]
+                Input.Placeholder textPlaceholder
+                Input.OnChange (getTextEventValue >> Some >> SetPopupDialogText >> dispatch)
+            ]
+
+            beforeInt1 dialogData
+            br []
+            Input.number [
+                Input.Props [OnPaste preventDefault; Style [Width "60px"]; AutoFocus true]
+                Input.DefaultValue <| sprintf "%d" intDefault1
+                Input.OnChange (getIntEventValue >> int64 >> setPopupTwoInts (FirstInt,None))
+            ]
+            br []
+            beforeInt2 dialogData
+            br []
+            Input.text [
+                Input.Props [OnPaste preventDefault; Style [Width "60px"]; AutoFocus true]
+                Input.DefaultValue <| sprintf "%d" intDefault2
+                Input.OnChange (fun ev ->
+                    let text = getTextEventValue ev
+                    let n = getInt64EventValue ev
+                    setPopupTwoInts(SecondInt, Some text) n)
+            ]
+        ]
+
 
 /// Create the body of a dialog Popup with both text and int.
 let dialogPopupBodyTextAndInt beforeText placeholder beforeInt intDefault dispatch =

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -150,7 +150,7 @@ let private makeNumberOfBitsField model (comp:Component) text dispatch =
     
     let title, width =
         match comp.Type with
-        | Input (w, _) | Output w | NbitsAdder w | NbitsXor w | Register w | RegisterE w | Viewer w -> "Number of bits", w
+        | Input1 (w, _) | Output w | NbitsAdder w | NbitsXor w | Register w | RegisterE w | Viewer w -> "Number of bits", w
         | SplitWire w -> "Number of bits in the top (LSB) wire", w
         | BusSelection( w, _) -> "Number of bits selected: width", w
         | BusCompare( w, _) -> "Bus width", w
@@ -184,7 +184,7 @@ let makeDefaultValueField (model: Model) (comp: Component) (text: string) dispat
 
     let width, defValue =
         match comp.Type with
-        | Input (w, defValue) ->
+        | Input1 (w, defValue) ->
             match defValue with
             | Some defValue -> w, defValue
             | None -> w, 0
@@ -295,7 +295,7 @@ let private makeDescription (comp:Component) model dispatch =
     match comp.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
-    | Input _ -> str "Input."
+    | Input1 _ -> str "Input."
     | Constant1 _ | Constant _ -> str "Constant Wire."
     | Output _ -> str "Output."
     | Viewer _ -> str "Viewer."
@@ -394,7 +394,7 @@ let private makeDescription (comp:Component) model dispatch =
 
 let private makeExtraInfo model (comp:Component) text dispatch : ReactElement =
     match comp.Type with
-    | Input _ ->
+    | Input1 _ ->
         div []
             [
                 makeNumberOfBitsField model comp text dispatch

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -295,6 +295,7 @@ let private makeDescription (comp:Component) model dispatch =
     match comp.Type with
     | ROM _ | RAM _ | AsyncROM _ -> 
         failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | Input1 _ -> str "Input."
     | Constant1 _ | Constant _ -> str "Constant Wire."
     | Output _ -> str "Output."

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -332,7 +332,8 @@ let update (msg : Msg) oldModel =
     | SetDragMode mode -> {model with DividerDragMode= mode}, Cmd.none
     | SetViewerWidth w ->
         {model with WaveSimViewerWidth = w}, Cmd.none
-    | ReloadSelectedComponent width -> {model with LastUsedDialogWidth=width}, Cmd.none
+    | ReloadSelectedComponent width ->
+        {model with LastUsedDialogWidth=width}, Cmd.none
     | StartSimulation simData -> 
         { model with CurrentStepSimulationStep = Some simData }, Cmd.none
     | SetWSModel wsModel -> 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -131,7 +131,7 @@ let getInputPortName (compType: ComponentType) (port: InputPortNumber) : string 
         | InputPortNumber 0 -> ".SEL"
         | _ -> ".DATA"
 
-    | Input _ | Output _ | Constant1 _ | Constant _ | Viewer _ ->
+    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ ->
         ""
     | DFF | Register _ ->
         ".D"
@@ -184,7 +184,7 @@ let getInputName (comp: NetListComponent) (port: InputPortNumber) : string =
         | DFF | Register _ | DFFE | RegisterE _ ->
             bitLimsString (0, 0)
 
-        | Input (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
+        | Input1 (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
         | NbitsXor w | NbitsAdder w  ->
             bitLimsString (w - 1, 0)
 
@@ -207,7 +207,7 @@ let getOutputPortName (compType: ComponentType) (port: OutputPortNumber) : strin
     match compType with
     | Not | And | Or | Xor | Nand | Nor | Xnor | Decode4 | Mux2 | Mux4 | Mux8 | BusCompare _ | NbitsXor _ ->
         ".OUT"
-    | Input _ | Output _ | Constant1 _ | Constant _ | Viewer _ | IOLabel ->
+    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ | IOLabel ->
         ""
     | Demux2 | Demux4 | Demux8 ->
         "." + string port
@@ -238,7 +238,7 @@ let getOutputName (comp: NetListComponent) (port: OutputPortNumber) (fastSim: Fa
         | DFF | DFFE ->
             bitLimsString (0, 0)
 
-        | Input (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
+        | Input1 (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
         | NbitsXor w | NbitsAdder w | Register w | RegisterE w ->
             bitLimsString (w - 1, 0)
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -184,7 +184,7 @@ let getInputName (comp: NetListComponent) (port: InputPortNumber) : string =
         | DFF | Register _ | DFFE | RegisterE _ ->
             bitLimsString (0, 0)
 
-        | Input w | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
+        | Input (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
         | NbitsXor w | NbitsAdder w  ->
             bitLimsString (w - 1, 0)
 
@@ -238,7 +238,7 @@ let getOutputName (comp: NetListComponent) (port: OutputPortNumber) (fastSim: Fa
         | DFF | DFFE ->
             bitLimsString (0, 0)
 
-        | Input w | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
+        | Input (w, _) | Output w | Constant1 (w, _, _) | Constant (w, _) | Viewer w
         | NbitsXor w | NbitsAdder w | Register w | RegisterE w ->
             bitLimsString (w - 1, 0)
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -170,6 +170,7 @@ let getInputPortName (compType: ComponentType) (port: InputPortNumber) : string 
         "." + fst c.InputLabels[getInputPortNumber port]
 
     | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | IOLabel -> failwithf "IOLabel should not occur in getInputPortName"
     | MergeWires -> failwithf "MergeWires should not occur in getInputPortName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getInputPortName"
@@ -196,6 +197,7 @@ let getInputName (comp: NetListComponent) (port: InputPortNumber) : string =
             bitLimsString (snd c.InputLabels[getInputPortNumber port] - 1, 0)
 
         | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
+        | Input _ -> failwithf "Legacy Input component types should never occur"
         | IOLabel -> failwithf "IOLabel should not occur in getInputName"
         | MergeWires -> failwithf "MergeWires should not occur in getInputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getInputName"
@@ -225,6 +227,7 @@ let getOutputPortName (compType: ComponentType) (port: OutputPortNumber) : strin
         "." + fst c.OutputLabels[getOutputPortNumber port]
 
     | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
+    | Input _ -> failwithf "Legacy Input component types should never occur"
     | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
     | BusSelection _ -> failwithf "BusSeleciton should not occur in getOutputName"
@@ -258,9 +261,10 @@ let getOutputName (comp: NetListComponent) (port: OutputPortNumber) (fastSim: Fa
                 bitLimsString (width - 1, 0)
 
         | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
+        | Input _ -> failwithf "Legacy Input component types should never occur"
         | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
-        | BusSelection _ -> failwithf "BusSeleciton should not occur in getOutputName"
+        | BusSelection _ -> failwithf "BusSelection should not occur in getOutputName"
 
     comp.Label + portName + bitLims
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -496,7 +496,7 @@ let selectWaves (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
         |> List.sortBy (fun wave -> wave.DisplayName)
         |> List.groupBy (fun wave ->
             match wave.Type with
-            | Input _ | Output _ | Constant1 _ ->
+            | Input1 _ | Output _ | Constant1 _ ->
                 InputOutput
             | IOLabel ->
                 WireLabel
@@ -519,7 +519,7 @@ let selectWaves (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
                 Component wave.CompLabel
             | BusSelection _ | MergeWires | SplitWire _ ->
                 failwithf "Bus select, MergeWires, SplitWire should not appear"
-            | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
+            | Input _ | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
                 failwithf "Legacy component types should not appear"
         )
         |> List.map (fun (compGroup, waves) ->


### PR DESCRIPTION
Closes #66 and #160.
Closes [jzzheng22/issie/#17](https://github.com/jzzheng22/issie/issues/17)

This PR adds support for Input components to have a default value when they are not driven.

Default values can be set on component creation or in the Properties tab.

This requires the addition of the `ComponentType` `Input1`, with `ComponentType.Input` becoming a legacy component type.
Any old Issie sheets should automatically have their `Input` types converted to `Input` types on loading the saved file.