### PR TITLE
Conditionally display values on non-binary waves

### DIFF
--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -26,7 +26,7 @@ let displayValuesOnWave wsModel (waveValues: WireData list) (transitions: NonBin
         |> List.filter (fun (i, x) -> x = Change)
         |> List.map (fun (i, x) -> i)
 
-    let gaps =
+    let gaps : Gap list =
         // Append dummy transition to end to check final gap length
         changeTransitions @ [Constants.maxLastClk]
         |> List.pairwise
@@ -39,7 +39,10 @@ let displayValuesOnWave wsModel (waveValues: WireData list) (transitions: NonBin
 
     gaps
     |> List.map (fun gap ->
-        let waveValue = string (convertWireDataToInt waveValues[gap.Start])
+        let waveValue =
+            convertWireDataToInt waveValues[gap.Start]
+            |> valToString wsModel.Radix
+
         let availableWidth = float gap.Length * (zoomLevel wsModel) - 2. * Constants.nonBinaryTransLen
         let requiredWidth = DrawHelpers.getTextWidthInPixels (waveValue, Constants.valueOnWaveText)
         let widthWithPadding = requiredWidth + Constants.valueOnWavePadding
@@ -462,7 +465,7 @@ let private radixButtons (wsModel: WaveSimModel) (dispatch: Msg -> unit) : React
             Tabs.Tab.Props radixTabProps
         ] [ a [
             radixTabAStyle
-            OnClick(fun _ -> dispatch <| SetWSModel {wsModel with Radix = radix})
+            OnClick(fun _ -> dispatch <| InitiateWaveSimulation {wsModel with Radix = radix})
             ] [ str radixStr ]
         ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -32,6 +32,15 @@ type Transition =
     | BinaryTransition of BinaryTransition
     | NonBinaryTransition of NonBinaryTransition
 
+/// Stores information about gaps between NonBinaryTransitions.
+/// Used in displayValuesOnWave
+type Gap = {
+    // First cycle which is Change after a Const cycle
+    Start: int
+    // How many Const cycles there are immediately after this Change transition
+    Length: int
+}
+
 type SelectionMenu = 
     | WireLabels
     | Components of string

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -23,6 +23,10 @@ module Constants =
     let clkLineWidth = 0.0125
     let lineThickness : float = 0.025
 
+    let fontSizeValueOnWave = "0.3px"
+    let valueOnWaveText = { DrawHelpers.defaultText with FontSize = fontSizeValueOnWave }
+    let valueOnWavePadding = 10.0
+
 let topRowStyle = Style [
     Height Constants.rowHeight
     BorderBottom "2px solid rgb(219,219,219)"
@@ -143,6 +147,15 @@ let zoomInSVG =
                 C125.535,77.047,122.178,73.689,118.035,73.689z"
             ] []
         ]
+
+let valueOnWaveProps m i start width : IProp list =
+    [
+        X (float start * (zoomLevel m) + Constants.nonBinaryTransLen + float i * width)
+        Y 0.6
+        Style [
+            FontSize Constants.fontSizeValueOnWave
+        ]
+    ]
 
 let clkCycleButtonStyle = Style [
     Float FloatOptions.Right


### PR DESCRIPTION
This PR allows for non-binary waves (i.e. waves with bit-width greater than 1) to conditionally display the values of that waveform.

Display is conditional on there being enough space.

Values are repeated if there is enough space.