### PR TITLE
Add support for viewing RAM contents in waveform simulator

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -269,6 +269,8 @@ module CommonTypes
         OutputLabels: (string * int) list
     }
 
+    /// Note that any memory addresses which have not been explicitly set when printing
+    /// out memory data.
     type Memory = {
         // How many bits the address should have.
         // The memory will have 2^AddressWidth memory locations.

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -320,9 +320,10 @@ module CommonTypes
         | MergeWires | SplitWire of BusWidth: int // int is bus width
         // DFFE is a DFF with an enable signal.
         // No initial state for DFF or Register? Default 0.
-        | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int 
-        | AsyncROM of Memory | ROM of Memory | RAM of Memory // legacy components - to be deleted
+        | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
         | AsyncROM1 of Memory1 | ROM1 of Memory1 | RAM1 of Memory1 | AsyncRAM1 of Memory1
+        // legacy components - to be deleted
+        | AsyncROM of Memory | ROM of Memory | RAM of Memory
 
     /// Active pattern which matches 2-input gate component types.
     /// NB - NOT gates are not included here.

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -618,6 +618,7 @@ module CommonTypes
         Radix: NumberBase option
         ZoomLevelIndex: int option
         WaveformColumnWidth: int option
+        SelectedRams: Map<ComponentId, string> option
 
         ClkWidth: float option
         Cursor: uint32 option

--- a/src/Renderer/Simulator/FastRun.fs
+++ b/src/Renderer/Simulator/FastRun.fs
@@ -418,7 +418,7 @@ let rec extractFastSimulationOutput
 let rec extractFastSimulationState
     (fs: FastSimulation)
     (step: int)
-    ((cid, ap): ComponentId * ComponentId list) =
+    ((cid, ap): ComponentId * ComponentId list) : SimulationComponentState =
 
     match Map.tryFind (cid, ap) fs.FComps with
     | Some fc ->

--- a/src/Renderer/UI/MemoryEditorView.fs
+++ b/src/Renderer/UI/MemoryEditorView.fs
@@ -248,7 +248,7 @@ let private makeEditorBody memory compId memoryEditorData model (dispatch: Msg -
                 ]
             ]
         ]
-        
+
     div [bodyStyle] [
         str isReadOnly
         br []

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -160,6 +160,10 @@ type WaveSimModel = {
     Radix: NumberBase
     ZoomLevelIndex: int
     WaveformColumnWidth: int
+    RamModalActive: bool
+    RamComponents: Component list
+    SelectedRamComponents: Component list
+    FastSim: FastSimulation
 }
 
 /// TODO: Decide a better number then move to Constants module.
@@ -178,6 +182,10 @@ let initWSModel : WaveSimModel = {
     Radix = Hex
     ZoomLevelIndex = 9
     WaveformColumnWidth = initialWaveformColWidth
+    RamModalActive = false
+    RamComponents = []
+    SelectedRamComponents = []
+    FastSim = FastCreate.emptyFastSimulation ()
 }
 
 type DiagEl = | Comp of Component | Conn of Connection

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -165,6 +165,7 @@ type WaveSimModel = {
     RamComponents: Component list
     SelectedRams: Map<ComponentId, string>
     FastSim: FastSimulation
+    SearchString: string
 }
 
 /// TODO: Decide a better number then move to Constants module.
@@ -188,6 +189,7 @@ let initWSModel : WaveSimModel = {
     RamComponents = []
     SelectedRams = Map.empty
     FastSim = FastCreate.emptyFastSimulation ()
+    SearchString = ""
 }
 
 type DiagEl = | Comp of Component | Conn of Connection

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -160,6 +160,7 @@ type WaveSimModel = {
     Radix: NumberBase
     ZoomLevelIndex: int
     WaveformColumnWidth: int
+    WaveModalActive: bool
     RamModalActive: bool
     RamComponents: Component list
     SelectedRams: Map<ComponentId, string>
@@ -182,6 +183,7 @@ let initWSModel : WaveSimModel = {
     Radix = Hex
     ZoomLevelIndex = 9
     WaveformColumnWidth = initialWaveformColWidth
+    WaveModalActive = false
     RamModalActive = false
     RamComponents = []
     SelectedRams = Map.empty

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -162,7 +162,7 @@ type WaveSimModel = {
     WaveformColumnWidth: int
     RamModalActive: bool
     RamComponents: Component list
-    SelectedRamComponents: Component list
+    SelectedRams: Map<ComponentId, string>
     FastSim: FastSimulation
 }
 
@@ -184,7 +184,7 @@ let initWSModel : WaveSimModel = {
     WaveformColumnWidth = initialWaveformColWidth
     RamModalActive = false
     RamComponents = []
-    SelectedRamComponents = []
+    SelectedRams = Map.empty
     FastSim = FastCreate.emptyFastSimulation ()
 }
 
@@ -453,6 +453,7 @@ let getSavedWaveInfo (wsModel: WaveSimModel) : SavedWaveInfo =
         Radix = Some wsModel.Radix
         ZoomLevelIndex = Some wsModel.ZoomLevelIndex
         WaveformColumnWidth = Some wsModel.WaveformColumnWidth
+        SelectedRams = Some wsModel.SelectedRams
 
         // The following fields are from the old waveform simulator.
         ClkWidth = None
@@ -473,6 +474,7 @@ let loadWSModelFromSavedWaveInfo (swInfo: SavedWaveInfo) : WaveSimModel =
             Radix = Option.defaultValue initWSModel.Radix swInfo.Radix
             ZoomLevelIndex = Option.defaultValue initWSModel.ZoomLevelIndex swInfo.ZoomLevelIndex
             WaveformColumnWidth = Option.defaultValue initWSModel.WaveformColumnWidth swInfo.WaveformColumnWidth
+            SelectedRams = Option.defaultValue initWSModel.SelectedRams swInfo.SelectedRams
     }
 
 //----------------------Print functions-----------------------------//

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -348,8 +348,7 @@ let update (msg : Msg) oldModel =
             WaveSim = Map.add sheet wsModel model.WaveSim
         }, Cmd.none
     | InitiateWaveSimulation wsModel ->
-        // printf "initiate wave sim"
-
+        printf "InitiateWaveSimulation"
         let allWaves = Map.map (WaveSim.generateWaveform wsModel) wsModel.AllWaves
         let wsModel' = {wsModel with AllWaves = allWaves}
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -506,26 +506,8 @@ let selectWavesModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElem
                     Level.level [] [
                         Level.left [] [ str "Select RAM" ]
                         Level.right [
-                            Modifiers [
-                                Modifier.BackgroundColor IsSuccess
-                            ]
-                        ] [
-                            Level.item [
-                                Level.Item.Option.Modifiers [
-                                    Modifier.BackgroundColor IsSuccess
-                                ]
-                            ] [
-                                Delete.delete [
-                                    Delete.Modifiers [
-                                        Modifier.TextColor IsSuccess
-                                    ]
-                                    Delete.Option.OnClick (fun _ -> dispatch <| SetWSModel {wsModel with WaveModalActive = false})
-                                ] []
-                            ]
-                            Delete.delete [
-                                Delete.Modifiers [
-                                    Modifier.TextColor IsSuccess
-                                ]
+                        ] [ Delete.delete [
+                                Delete.Option.Size IsMedium
                                 Delete.Option.OnClick (fun _ -> dispatch <| SetWSModel {wsModel with WaveModalActive = false})
                             ] []
                         ]
@@ -591,6 +573,7 @@ let selectRamModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElemen
                         Level.left [] [ str "Select RAM" ]
                         Level.right [] [
                             Delete.delete [
+                                Delete.Option.Size IsMedium
                                 Delete.Option.OnClick (fun _ -> dispatch <| SetWSModel {wsModel with RamModalActive = false})
                             ] []
                         ]
@@ -611,16 +594,6 @@ let selectRamModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElemen
             Modal.Card.foot [] []
         ]
     ]
-
-/// Buttons to close waveform simulator, select waves, and select RAMs
-let selectBar (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
-    Level.level [ Level.Level.Option.Props [waveSimButtonsBarStyle] ]
-        [
-            selectWavesButton wsModel dispatch
-            selectWavesModal wsModel dispatch
-            selectRamButton wsModel dispatch
-            selectRamModal wsModel dispatch
-        ]
 
 /// Set highlighted clock cycle number
 let private setClkCycle (wsModel: WaveSimModel) (dispatch: Msg -> unit) (newClkCycle: int) : unit =
@@ -755,18 +728,6 @@ let private radixButtons (wsModel: WaveSimModel) (dispatch: Msg -> unit) : React
         Tabs.IsToggle
         Tabs.Props [ radixTabsStyle ]
     ] (List.map (radixTab) radixString)
-
-/// Buttons to change radix, change zoom, and change clock cycle
-let paramsBar (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
-    Level.level [ Level.Level.Option.Props [waveSimButtonsBarStyle] ]
-        [   
-            // Level.left [] []
-            // Level.right [] [
-            radixButtons wsModel dispatch
-            clkCycleButtons wsModel dispatch
-            zoomButtons wsModel dispatch
-        ]
-    // ]
 
 
 // /// change the order of the waveforms in the simulator
@@ -1009,12 +970,40 @@ let wsOpenPane (wsModel: WaveSimModel) dispatch : ReactElement =
                     ] []
                 ]
             ]
-            str "Some instructions here"
 
-            hr []
+            Columns.columns [] [
+                Column.column [] [
+                    str "View sequential logic using the waveform simulator by selecting desired waveforms. "
+                    str "Select synchronous RAM components to view their contents during the simulation. "
+                    str "You must restart the waveform simulator to view any changes to the circuit. "
+                ]
 
-            selectBar wsModel dispatch
-            paramsBar wsModel dispatch
+                Column.column [
+                    Column.Option.Width (Screen.All, Column.IsNarrow)
+                ] [ Level.level [] [
+                        Level.item [
+                                Level.Item.Option.HasTextCentered
+                            ] [ Button.list [] [
+                                selectWavesButton wsModel dispatch
+                                selectWavesModal wsModel dispatch
+
+                                selectRamButton wsModel dispatch
+                                selectRamModal wsModel dispatch
+                            ]
+                            ]
+                        ]
+                    Level.level [] [
+                        Level.left [] [
+                            zoomButtons wsModel dispatch
+                        ]
+                        Level.right [] [
+                            radixButtons wsModel dispatch
+                        ]
+                    ]
+                    clkCycleButtons wsModel dispatch
+                ]
+            ]
+
             showWaveforms wsModel dispatch
 
             hr []

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -985,56 +985,64 @@ let ramTables (wsModel: WaveSimModel) : ReactElement =
             (List.map (ramTable wsModel) selectedRams)
     else div [] []
 
+/// ReactElement showing instruments and wave sim buttons
+let topHalf (wsModel: WaveSimModel) dispatch : ReactElement =
+    div [ topHalfStyle ] [
+        br []
+        Level.level [] [
+            Level.left [] [
+                Heading.h4 [] [ str "Waveform Simulator" ]
+            ]
+            Level.right [] [
+                Delete.delete [
+                    Delete.Option.Size IsLarge
+                    Delete.Option.Modifiers [
+                        Modifier.BackgroundColor IsGreyLight
+                    ]
+                    Delete.Option.OnClick (fun _ -> dispatch <| SetWSModel {wsModel with State = WSClosed})
+                ] []
+            ]
+        ]
+
+        Columns.columns [] [
+            Column.column [] [
+                str "View sequential logic using the waveform simulator by selecting desired waveforms. "
+                str "Select synchronous RAM components to view their contents during the simulation. "
+                str "You must restart the waveform simulator to view any changes to the circuit. "
+            ]
+
+            Column.column [
+                Column.Option.Width (Screen.All, Column.IsNarrow)
+            ] [ Level.level [] [
+                    Level.item [ ] [
+                        Button.list [] [
+                            selectWavesButton wsModel dispatch
+                            selectWavesModal wsModel dispatch
+
+                            selectRamButton wsModel dispatch
+                            selectRamModal wsModel dispatch
+                        ]
+                    ]
+                ]
+                Level.level [] [
+                    Level.left [] [
+                        zoomButtons wsModel dispatch
+                    ]
+                    Level.right [] [
+                        radixButtons wsModel dispatch
+                    ]
+                ]
+                clkCycleButtons wsModel dispatch
+            ]
+        ]
+        hr [ Style [ MarginBottom "5px" ] ]
+        br []
+    ]
+
 let wsOpenPane (wsModel: WaveSimModel) dispatch : ReactElement =
     div [ waveSelectionPaneStyle ]
         [
-            Level.level [] [
-                Level.left [] [
-                    Heading.h4 [] [ str "Waveform Simulator" ]
-                ]
-                Level.right [] [
-                    Delete.delete [
-                        Delete.Option.Size IsLarge
-                        Delete.Option.Modifiers [
-                            Modifier.BackgroundColor IsGreyLight
-                        ]
-                        Delete.Option.OnClick (fun _ -> dispatch <| SetWSModel {wsModel with State = WSClosed})
-                    ] []
-                ]
-            ]
-
-            Columns.columns [] [
-                Column.column [] [
-                    str "View sequential logic using the waveform simulator by selecting desired waveforms. "
-                    str "Select synchronous RAM components to view their contents during the simulation. "
-                    str "You must restart the waveform simulator to view any changes to the circuit. "
-                ]
-
-                Column.column [
-                    Column.Option.Width (Screen.All, Column.IsNarrow)
-                ] [ Level.level [] [
-                        Level.item [
-                                Level.Item.Option.HasTextCentered
-                            ] [ Button.list [] [
-                                    selectWavesButton wsModel dispatch
-                                    selectWavesModal wsModel dispatch
-
-                                    selectRamButton wsModel dispatch
-                                    selectRamModal wsModel dispatch
-                                ]
-                            ]
-                        ]
-                    Level.level [] [
-                        Level.left [] [
-                            zoomButtons wsModel dispatch
-                        ]
-                        Level.right [] [
-                            radixButtons wsModel dispatch
-                        ]
-                    ]
-                    clkCycleButtons wsModel dispatch
-                ]
-            ]
+            topHalf wsModel dispatch
 
             showWaveforms wsModel dispatch
 
@@ -1043,7 +1051,6 @@ let wsOpenPane (wsModel: WaveSimModel) dispatch : ReactElement =
             ramTables wsModel
 
             hr []
-
         ]
 
 /// Entry point to the waveform simulator. This function returns a ReactElement showing

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -995,12 +995,12 @@ let wsOpenPane (wsModel: WaveSimModel) dispatch : ReactElement =
                         Level.item [
                                 Level.Item.Option.HasTextCentered
                             ] [ Button.list [] [
-                                selectWavesButton wsModel dispatch
-                                selectWavesModal wsModel dispatch
+                                    selectWavesButton wsModel dispatch
+                                    selectWavesModal wsModel dispatch
 
-                                selectRamButton wsModel dispatch
-                                selectRamModal wsModel dispatch
-                            ]
+                                    selectRamButton wsModel dispatch
+                                    selectRamModal wsModel dispatch
+                                ]
                             ]
                         ]
                     Level.level [] [

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -444,16 +444,17 @@ let selectWaves (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
                 Gates
             | BusCompare _ ->
                 Buses
-            | Mux2 | Mux4 | Mux8 | Demux2 | Demux4 | Demux8 | Decode4 ->
-                MuxDemux
-            | NbitsAdder _ | NbitsXor _ ->
-                Arithmetic
-            | Custom _ ->
-                CustomComp
-            | DFF | DFFE | Register _ | RegisterE _ ->
-                FFRegister
+            | Mux2 | Mux4 | Mux8 | Demux2 | Demux4 | Demux8 | Decode4
+                // MuxDemux
+            | NbitsAdder _ | NbitsXor _
+                // Arithmetic
+            | Custom _
+                // CustomComp
+            | DFF | DFFE | Register _ | RegisterE _
+                // FFRegister
             | AsyncROM1 _ | ROM1 _ | RAM1 _ | AsyncRAM1 _ ->
-                Memories
+                // Memories
+                Component wave.CompLabel
             | BusSelection _ | MergeWires | SplitWire _ ->
                 failwithf "Bus select, MergeWires, SplitWire should not appear"
             | Constant _ | AsyncROM _ | ROM _ | RAM _ ->

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -430,9 +430,23 @@ let labelRows (compGroup: ComponentGroup) (waves: Wave list) (wsModel: WaveSimMo
         ]
     ]
 
+let searchBar (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
+    Input.text [
+        Input.Option.Props [
+            Style [
+                MarginBottom "1rem"
+            ]
+        ]
+        Input.Option.Placeholder "Search"
+        Input.Option.OnChange (fun c ->
+            dispatch <| SetWSModel {wsModel with SearchString = c.Value.ToUpper()}
+        )
+    ]
+
 let selectWaves (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
     let selectionRows : ReactElement list =
         Map.values wsModel.AllWaves |> Seq.toList
+        |> List.filter (fun x -> x.DisplayName.ToUpper().Contains(wsModel.SearchString))
         |> List.sortBy (fun wave -> wave.DisplayName)
         |> List.groupBy (fun wave ->
             match wave.Type with
@@ -511,6 +525,7 @@ let selectWavesModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElem
                 ]
             ]
             Modal.Card.body [] [
+                searchBar wsModel dispatch
                 selectWaves wsModel dispatch
             ]
             Modal.Card.foot [] []

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -41,9 +41,16 @@ type Gap = {
     Length: int
 }
 
-type SelectionMenu = 
-    | WireLabels
-    | Components of string
+type ComponentGroup =
+    | InputOutput
+    | WireLabel
+    | Buses
+    | Gates
+    | MuxDemux
+    | Arithmetic
+    | CustomComp
+    | FFRegister
+    | Memories
 
 module Constants = 
     let nonBinaryTransLen : float = 0.2
@@ -215,9 +222,22 @@ let waveNames (wsModel: WaveSimModel) : string list =
 /// get integer from OutputPortNumber
 let getInputPortNumber (ipn: InputPortNumber) : int =
     match ipn with
-    | CommonTypes.InputPortNumber pn -> pn
+    | InputPortNumber pn -> pn
 
 /// get integer from OutputPortNumber
 let getOutputPortNumber (opn: OutputPortNumber) : int =
     match opn with
-    | CommonTypes.OutputPortNumber pn -> pn
+    | OutputPortNumber pn -> pn
+
+let summaryName (compGroup: ComponentGroup) : ReactElement =
+    match compGroup with
+    | WireLabel -> "Wire Labels"
+    | InputOutput -> "Inputs / Outputs"
+    | Buses -> "Buses"
+    | Gates -> "Logic Gates"
+    | MuxDemux -> "Multiplexers"
+    | Arithmetic -> "Arithmetic"
+    | CustomComp _ -> "Custom Components"
+    | FFRegister -> "Flip Flops and Registers"
+    | Memories -> "RAMs and ROMs"
+    |> str

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -46,11 +46,12 @@ type ComponentGroup =
     | WireLabel
     | Buses
     | Gates
-    | MuxDemux
-    | Arithmetic
-    | CustomComp
-    | FFRegister
-    | Memories
+    // | MuxDemux
+    // | Arithmetic
+    // | CustomComp
+    // | FFRegister
+    // | Memories
+    | Component of string
 
 module Constants = 
     let nonBinaryTransLen : float = 0.2
@@ -235,9 +236,10 @@ let summaryName (compGroup: ComponentGroup) : ReactElement =
     | InputOutput -> "Inputs / Outputs"
     | Buses -> "Buses"
     | Gates -> "Logic Gates"
-    | MuxDemux -> "Multiplexers"
-    | Arithmetic -> "Arithmetic"
-    | CustomComp _ -> "Custom Components"
-    | FFRegister -> "Flip Flops and Registers"
-    | Memories -> "RAMs and ROMs"
+    // | MuxDemux -> "Multiplexers"
+    // | Arithmetic -> "Arithmetic"
+    // | CustomComp _ -> "Custom Components"
+    // | FFRegister -> "Flip Flops and Registers"
+    // | Memories -> "RAMs and ROMs"
+    | Component compLabel -> compLabel
     |> str

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -150,7 +150,17 @@ let ramTablesLevelProps : IHTMLProp list = [
 
 let ramTableRowStyle wenHigh correctAddr =
     if wenHigh && correctAddr then
-        Style [ BackgroundColor "hsl(206, 70%, 96%)" ]
+        Style [
+            BackgroundColor "hsl(347, 90%, 96%)"
+            Color "hsl(348, 100%, 61%)"
+            FontWeight "bold"
+        ]
+    else if correctAddr then
+        Style [
+            BackgroundColor "hsl(206, 70%, 96%)"
+            Color "hsl(204, 86%, 53%)"
+            FontWeight "bold"
+        ]
     else Style []
 
 let zoomOutSVG =

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -103,7 +103,6 @@ let selectWavesStyle = Style [
 let closeWaveSimButtonStyle = Style [
     Height Constants.rowHeight
     FontSize "16px"
-    Float FloatOptions.Left
     Position PositionOptions.Relative
 ]
 
@@ -118,8 +117,6 @@ let selectRamButtonPropsLight =
 let selectWavesButtonStyle = Style [
     Height Constants.rowHeight
     FontSize "16px"
-    Float FloatOptions.Left
-    Position PositionOptions.Relative
 ]
 
 let selectWavesButtonProps = [
@@ -203,7 +200,6 @@ let clkCycleButtonStyle = Style [
     TextAlign TextAlignOptions.Center
     Display DisplayOptions.InlineBlock
     FontSize "13px"
-    Resize "vertical"
 ]
 
 // TODO: Can this be nested inside clkCycleButtonStyle
@@ -215,9 +211,8 @@ let clkCycleInputStyle = Style [
     Height Constants.rowHeight
     Display DisplayOptions.InlineBlock
     FontSize "13px"
-    Resize "vertical"
     BorderColor "gray"
-    BorderWidth "1px 1px 1px 1px"
+    BorderWidth "1px 0.5px 1px 0.5px"
     BorderRadius 0
 ]
 
@@ -236,7 +231,7 @@ let clkCycleBut = [
     Position PositionOptions.Relative
     Float FloatOptions.Left
     BorderColor "gray"
-    BorderWidth "1px"
+    BorderWidth "1px 0.5px 1px 0.5px"
 ]
 
 let clkCycleInnerStyle = Style (
@@ -251,6 +246,7 @@ let clkCycleLeftStyle = Style (
         BorderBottomLeftRadius "4px"
         BorderTopRightRadius 0
         BorderBottomRightRadius 0
+        BorderRightWidth "0.5"
     ])
 
 let clkCycleRightStyle = Style (
@@ -259,6 +255,7 @@ let clkCycleRightStyle = Style (
         BorderBottomLeftRadius 0
         BorderTopRightRadius "4px"
         BorderBottomRightRadius "4px"
+        BorderLeftWidth "0.5"
     ])
 
 let waveSimButtonsBarStyle = Style [ Height "45px" ]
@@ -437,11 +434,9 @@ let radixTabAStyle = Style [
 ]
 
 let radixTabsStyle = Style [
-    Width "140px"
     Height Constants.rowHeight
     FontSize "80%"
     Float FloatOptions.Right
-    Margin "0 10px 0 10px"
 ]
 
 let wavePolylineStyle points : IProp list = [

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -148,6 +148,11 @@ let ramTablesLevelProps : IHTMLProp list = [
     ]
 ]
 
+let ramTableRowStyle wenHigh correctAddr =
+    if wenHigh && correctAddr then
+        Style [ BackgroundColor "hsl(206, 70%, 96%)" ]
+    else Style []
+
 let zoomOutSVG =
     svg [
             ViewBox "0 0 192.904 192.904"

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -100,15 +100,16 @@ let selectWavesStyle = Style [
     Position PositionOptions.Relative
 ]
 
-let closeWaveSimButtonStyle = Style [
+let selectRamButtonStyle = Style [
     Height Constants.rowHeight
     FontSize "16px"
     Position PositionOptions.Relative
+    MarginRight 0
 ]
 
 let selectRamButtonProps = [
     Button.Color IsInfo
-    Button.Props [closeWaveSimButtonStyle]
+    Button.Props [selectRamButtonStyle]
 ]
 
 let selectRamButtonPropsLight = 
@@ -117,6 +118,8 @@ let selectRamButtonPropsLight =
 let selectWavesButtonStyle = Style [
     Height Constants.rowHeight
     FontSize "16px"
+    Position PositionOptions.Relative
+    MarginLeft 0
 ]
 
 let selectWavesButtonProps = [

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -105,16 +105,30 @@ let closeWaveSimButtonStyle = Style [
     FontSize "16px"
     Float FloatOptions.Left
     Position PositionOptions.Relative
-    MarginRight 10
 ]
 
 let selectRamButtonProps = [
-    Button.Color IsSuccess
+    Button.Color IsInfo
     Button.Props [closeWaveSimButtonStyle]
 ]
 
 let selectRamButtonPropsLight = 
     selectRamButtonProps @ [Button.IsLight]
+
+let selectWavesButtonStyle = Style [
+    Height Constants.rowHeight
+    FontSize "16px"
+    Float FloatOptions.Left
+    Position PositionOptions.Relative
+]
+
+let selectWavesButtonProps = [
+    Button.Color IsInfo
+    Button.Props [selectWavesButtonStyle]
+]
+
+let selectWavesButtonPropsLight = 
+    selectWavesButtonProps @ [Button.IsLight]
 
 let ramTableLevelProps : IHTMLProp list = [
     Style [

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -465,3 +465,10 @@ let summaryProps : IHTMLProp list = [
 let detailsProps : IHTMLProp list = [
     Open false
 ]
+
+let topHalfStyle = Style [
+    Position PositionOptions.Sticky
+    Top 0
+    BackgroundColor "white"
+    ZIndex 10000
+]

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -105,8 +105,33 @@ let closeWaveSimButtonStyle = Style [
     FontSize "16px"
     Float FloatOptions.Left
     Position PositionOptions.Relative
-    Margin "0 0 0 0"
+    MarginRight 10
+]
 
+let selectRamButtonProps = [
+    Button.Color IsSuccess
+    Button.Props [closeWaveSimButtonStyle]
+]
+
+let selectRamButtonPropsLight = 
+    selectRamButtonProps @ [Button.IsLight]
+
+let ramTableLevelProps : IHTMLProp list = [
+    Style [
+        Position PositionOptions.Relative
+        Display DisplayOptions.InlineBlock
+        MarginRight 10
+    ]
+]
+
+let centerAlignStyle = Style [
+    TextAlign TextAlignOptions.Center
+]
+
+let ramTablesLevelProps : IHTMLProp list = [
+    Style [
+        OverflowX OverflowOptions.Scroll
+    ]
 ]
 
 let zoomOutSVG =
@@ -248,6 +273,10 @@ let upDownButtonStyle = Style [
 let labelStyle = Style [
     Height Constants.rowHeight
     BorderBottom "1px solid rgb(219,219,219)"
+]
+
+let ramRowStyle = Style [
+    Height Constants.rowHeight
 ]
 
 let borderProperties = "2px solid rgb(219,219,219)"


### PR DESCRIPTION
This PR adds support for viewing the contents of synchronous RAM components in the waveform simulator.

RAM contents is highlighted in red on a write, and highlighted in blue on a read.

The waveform simulator instructions and buttons remain at the top of the screen when scrolled so that users can still change simulation parameters without needing to scroll back to the top of the screen.

Waveform and RAM selection are now implemented using modals rather than a big table that is always visible on the screen.

Users can now search by name for waveforms. Note that search by component type is not supported (yet).