### PR TITLE
Change clock cycle by clicking on desired clock cycle

### DIFF
--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -831,7 +831,7 @@ let clkCycleNumberRow (wsModel: WaveSimModel) =
     |> svg (clkCycleNumberRowProps wsModel)
 
 /// Generate a column of waveforms corresponding to selected waves.
-let waveformColumn (wsModel: WaveSimModel) : ReactElement =
+let waveformColumn (wsModel: WaveSimModel) dispatch : ReactElement =
     /// Note that this is generated after calling selectedWaves.
     /// Any changes to this function must also be made to nameRows
     /// and valueRows, as the order of the waves matters here. This is
@@ -853,7 +853,7 @@ let waveformColumn (wsModel: WaveSimModel) : ReactElement =
 
     div [ waveformColumnStyle ]
         [
-            clkCycleHighlightSVG wsModel (List.length wsModel.SelectedWaves)
+            clkCycleHighlightSVG wsModel dispatch
             div [ waveRowsStyle wsModel.WaveformColumnWidth]
                 ([ clkCycleNumberRow wsModel ] @
                     waveRows
@@ -865,7 +865,7 @@ let showWaveforms (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement
     div [ showWaveformsStyle ]
         [
             namesColumn wsModel
-            waveformColumn wsModel
+            waveformColumn wsModel dispatch
             valuesColumn wsModel
         ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -419,7 +419,8 @@ let waveRowProps m : IProp list =
 ]
 
 /// Controls the background highlighting of which clock cycle is selected
-let clkCycleHighlightSVG m count = 
+let clkCycleHighlightSVG m dispatch =
+    let count = List.length m.SelectedWaves
     svg [
         Style [
             GridColumnStart 1
@@ -430,6 +431,17 @@ let clkCycleHighlightSVG m count =
         SVGAttr.Fill "rgb(230,230,230)"
         SVGAttr.Opacity 0.4
         ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string (Constants.viewBoxHeight * float (count + 1)))
+        Id "ClkCycleHighlight"
+        OnClick (fun ev ->
+            let svgEl = Browser.Dom.document.getElementById "ClkCycleHighlight"
+            let bcr = svgEl.getBoundingClientRect ()
+            let cycleWidth = bcr.width / float (shownCycles m)
+            /// ev.clientX is X-coord of mouse click. bcr.left is x-coord of start of SVG.
+            /// getBoundingClientRect only works if ViewBox is 0 0 width height, so
+            /// add m.StartCycle to account for when viewBoxMinX is not 0
+            let cycle = (int <| (ev.clientX - bcr.left) / cycleWidth) + m.StartCycle
+            dispatch <| SetWSModel {m with CurrClkCycle = cycle}
+        )
     ] [
         rect [
             SVGAttr.Width (zoomLevel m)


### PR DESCRIPTION
This PR allows users to change clock cycles by clicking on the waveform diagram: for example, clicking in the column for clock cycle 10 will change `wsModel.CurrClkCycle` to 10