### PR TITLE
Change zoom method

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -618,8 +618,8 @@ module CommonTypes
     type SavedWaveInfo = {
         SelectedWaves: WaveIndexT list option
         Radix: NumberBase option
-        ZoomLevelIndex: int option
         WaveformColumnWidth: int option
+        ShownCycles: int option
         SelectedRams: Map<ComponentId, string> option
 
         ClkWidth: float option

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -236,7 +236,8 @@ let displayView model dispatch =
             /// Unsure of why there needs to be 2* in front of dividerBarWidth... but it seems to work.
             let otherDivWidths = Constants.leftMargin + Constants.rightMargin + 2 * Constants.dividerBarWidth
 
-            let waveColWidth = w - otherDivWidths - Constants.namesColWidth - Constants.valuesColWidth
+            /// Require at least one visible clock cycle
+            let waveColWidth = max (int (singleWaveWidth wsModel)) (w - otherDivWidths - Constants.namesColWidth - Constants.valuesColWidth)
             let wholeCycles = waveColWidth / int (singleWaveWidth wsModel)
             let wholeCycleWidth = wholeCycles * int (singleWaveWidth wsModel)
 

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -158,7 +158,6 @@ type WaveSimModel = {
     CurrClkCycle: int
     ClkCycleBoxIsEmpty: bool
     Radix: NumberBase
-    ZoomLevelIndex: int
     WaveformColumnWidth: int
     WaveModalActive: bool
     RamModalActive: bool
@@ -182,7 +181,6 @@ let initWSModel : WaveSimModel = {
     CurrClkCycle = 0
     ClkCycleBoxIsEmpty = false
     Radix = Hex
-    ZoomLevelIndex = 9
     WaveformColumnWidth = initialWaveformColWidth
     WaveModalActive = false
     RamModalActive = false
@@ -455,8 +453,8 @@ let getSavedWaveInfo (wsModel: WaveSimModel) : SavedWaveInfo =
     {
         SelectedWaves = Some wsModel.SelectedWaves
         Radix = Some wsModel.Radix
-        ZoomLevelIndex = Some wsModel.ZoomLevelIndex
         WaveformColumnWidth = Some wsModel.WaveformColumnWidth
+        ShownCycles = Some wsModel.ShownCycles
         SelectedRams = Some wsModel.SelectedRams
 
         // The following fields are from the old waveform simulator.
@@ -476,8 +474,8 @@ let loadWSModelFromSavedWaveInfo (swInfo: SavedWaveInfo) : WaveSimModel =
         initWSModel with
             SelectedWaves = Option.defaultValue initWSModel.SelectedWaves swInfo.SelectedWaves
             Radix = Option.defaultValue initWSModel.Radix swInfo.Radix
-            ZoomLevelIndex = Option.defaultValue initWSModel.ZoomLevelIndex swInfo.ZoomLevelIndex
             WaveformColumnWidth = Option.defaultValue initWSModel.WaveformColumnWidth swInfo.WaveformColumnWidth
+            ShownCycles = Option.defaultValue initWSModel.ShownCycles swInfo.ShownCycles
             SelectedRams = Option.defaultValue initWSModel.SelectedRams swInfo.SelectedRams
     }
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -20,12 +20,12 @@ module Constants =
     let rightMargin = 50
 
     let rowHeight = 30
-    let clkLineWidth = 0.0125
-    let lineThickness : float = 0.025
+    let clkLineWidth = 0.4
+    let lineThickness : float = 0.8
 
-    let fontSizeValueOnWave = "0.3px"
+    let fontSizeValueOnWave = "10px"
     let valueOnWaveText = { DrawHelpers.defaultText with FontSize = fontSizeValueOnWave }
-    let valueOnWavePadding = 10.0
+    let valueOnWavePadding = 150.0
 
 let topRowStyle = Style [
     Height Constants.rowHeight
@@ -204,8 +204,8 @@ let zoomInSVG =
 
 let valueOnWaveProps m i start width : IProp list =
     [
-        X (float start * (zoomLevel m) + Constants.nonBinaryTransLen + float i * width)
-        Y 0.6
+        X (float start * (singleWaveWidth m) + Constants.nonBinaryTransLen + float i * width)
+        Y (0.6 * Constants.viewBoxHeight)
         Style [
             FontSize Constants.fontSizeValueOnWave
         ]
@@ -384,10 +384,10 @@ let clkLineStyle = Style [
 
 let clkCycleText m i : IProp list =
     [
-        SVGAttr.FontSize "3.5%"
+        SVGAttr.FontSize "12px"
         SVGAttr.TextAnchor "middle"
-        X (zoomLevel m * (float i + 0.5))
-        Y 0.65
+        X (singleWaveWidth m * (float i + 0.5))
+        Y (0.6 * Constants.viewBoxHeight)
     ]
 
 let clkCycleSVGStyle = Style [
@@ -397,7 +397,7 @@ let clkCycleSVGStyle = Style [
 
 let waveformColumnRowProps m : IProp list = [
     SVGAttr.Height Constants.rowHeight
-    SVGAttr.Width (float (shownCycles m) * singleWaveWidth m)
+    SVGAttr.Width (viewBoxWidth m)
     // min-x, min-y, width, height
     ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string Constants.viewBoxHeight)
     PreserveAspectRatio "none"
@@ -427,7 +427,7 @@ let clkCycleHighlightSVG m dispatch =
             GridRowStart 1
         ]
         SVGAttr.Height (string ((count + 1) * Constants.rowHeight) + "px")
-        SVGAttr.Width (float (shownCycles m) * singleWaveWidth m)
+        SVGAttr.Width (viewBoxWidth m)
         SVGAttr.Fill "rgb(230,230,230)"
         SVGAttr.Opacity 0.4
         ViewBox (viewBoxMinX m + " 0 " + viewBoxWidth m  + " " + string (Constants.viewBoxHeight * float (count + 1)))
@@ -435,18 +435,19 @@ let clkCycleHighlightSVG m dispatch =
         OnClick (fun ev ->
             let svgEl = Browser.Dom.document.getElementById "ClkCycleHighlight"
             let bcr = svgEl.getBoundingClientRect ()
-            let cycleWidth = bcr.width / float (shownCycles m)
+            /// Should be the same as singleWaveWidth
+            let cycleWidth = bcr.width / float m.ShownCycles
             /// ev.clientX is X-coord of mouse click. bcr.left is x-coord of start of SVG.
             /// getBoundingClientRect only works if ViewBox is 0 0 width height, so
             /// add m.StartCycle to account for when viewBoxMinX is not 0
-            let cycle = (int <| (ev.clientX - bcr.left) / cycleWidth) + m.StartCycle
+            let cycle = (int <| (ev.clientX - bcr.left) / singleWaveWidth m) + m.StartCycle
             dispatch <| SetWSModel {m with CurrClkCycle = cycle}
         )
     ] [
         rect [
-            SVGAttr.Width (zoomLevel m)
+            SVGAttr.Width (singleWaveWidth m)
             SVGAttr.Height "100%"
-            X (float m.CurrClkCycle * zoomLevel m)
+            X (float m.CurrClkCycle * (singleWaveWidth m))
         ] []
     ]
 


### PR DESCRIPTION
Closes https://github.com/jzzheng22/issie/issues/42

This PR changes how zooming is handled within the waveform simulator.
When the wave sim is zoomed, the number of shown cycles is changed, rather than the width. That is, the width of a clock cycle is now dependent on the width of the waveform column and the number of visible cycles. Prior to this PR, the number of visible cycles was dependent on clock cycle width and the width of the waveform column.

This requires changing the size of the SVG viewbox.

There is now always guaranteed to be at least one visible clock cycle.

Clock cycle width is now a minimum of 5px.

`ZoomLevelIndex` has been removed from the `WaveSimModel`.