### PR TITLE
Add support for Viewer components in wave simulator

### DIFF
--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -42,8 +42,9 @@ type Gap = {
 }
 
 type ComponentGroup =
-    | InputOutput
     | WireLabel
+    | InputOutput
+    | Viewers
     | Buses
     | Gates
     // | MuxDemux
@@ -223,6 +224,7 @@ let summaryName (compGroup: ComponentGroup) : ReactElement =
     match compGroup with
     | WireLabel -> "Wire Labels"
     | InputOutput -> "Inputs / Outputs"
+    | Viewers -> "Viewers"
     | Buses -> "Buses"
     | Gates -> "Logic Gates"
     // | MuxDemux -> "Multiplexers"


### PR DESCRIPTION
This PR adds support for simulating Viewer components in the waveform simulator