### PR TITLE
Fix bug caused by not checking wsModel contains RAM

### DIFF
--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -353,7 +353,9 @@ let setupProjectFromComponents (sheetName: string) (ldComps: LoadedComponent lis
     match model.CurrentProj with
     | None -> ()
     | Some p ->
-        dispatch EndSimulation // Message ends any running simulation.
+        // Message ends any running simulation.
+        dispatch EndSimulation
+        dispatch EndWaveSim
         // TODO: make each sheet wavesim remember the list of waveforms.
     let waveSim =
         compToSetup.WaveInfo
@@ -601,7 +603,9 @@ let addFileToProject model dispatch =
 let forceCloseProject model dispatch =
     dispatch (StartUICmd CloseProject)
     let sheetDispatch sMsg = dispatch (Sheet sMsg) 
-    dispatch EndSimulation // End any running simulation.
+    // End any running simulation.
+    dispatch EndSimulation
+    dispatch EndWaveSim
     model.Sheet.ClearCanvas sheetDispatch
     dispatch FinishUICmd
 
@@ -634,7 +638,9 @@ let private newProject model dispatch  =
             log err
             displayFileErrorNotification err dispatch
         | Ok _ ->
-            dispatch EndSimulation // End any running simulation.
+            // End any running simulation.
+            dispatch EndSimulation
+            dispatch EndWaveSim
             // Create empty placeholder projectFile.
             let projectFile = baseName path + ".dprj"
             writeFile (pathJoin [| path; projectFile |]) ""

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -161,7 +161,7 @@ type WaveSimModel = {
     WaveformColumnWidth: int
     WaveModalActive: bool
     RamModalActive: bool
-    RamComponents: Component list
+    RamComps: Component list
     SelectedRams: Map<ComponentId, string>
     FastSim: FastSimulation
     SearchString: string
@@ -184,7 +184,7 @@ let initWSModel : WaveSimModel = {
     WaveformColumnWidth = initialWaveformColWidth
     WaveModalActive = false
     RamModalActive = false
-    RamComponents = []
+    RamComps = []
     SelectedRams = Map.empty
     FastSim = FastCreate.emptyFastSimulation ()
     SearchString = ""
@@ -233,6 +233,7 @@ type Msg =
     | SetSimulationBase of NumberBase
     | IncrementSimulationClockTick of int
     | EndSimulation
+    | EndWaveSim
     | ChangeRightTab of RightTab
     | ChangeSimSubTab of SimSubTab
     | SetHighlighted of ComponentId list * ConnectionId list

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -363,8 +363,9 @@ let update (msg : Msg) oldModel =
         let simData = getSimulationDataOrFail model "IncrementSimulationClockTick"
         { model with CurrentStepSimulationStep = { simData with ClockTickNumber = simData.ClockTickNumber + n } |> Ok |> Some }, Cmd.none
     | EndSimulation ->
-        let wsModel =  {WaveSimHelpers.getWSModel model with State = WSClosed }
-        { setWSModel wsModel model with CurrentStepSimulationStep = None }, Cmd.none
+        { model with CurrentStepSimulationStep = None }, Cmd.none
+    | EndWaveSim -> 
+        { model with WaveSim = Map.empty; WaveSimSheet = ""}, Cmd.none
     | ChangeRightTab newTab -> 
         let inferMsg = JSDiagramMsg <| InferWidths()
         let editCmds = [inferMsg; ClosePropertiesNotification] |> List.map Cmd.ofMsg

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -572,7 +572,7 @@ let selectWavesModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElem
     ]
 
 let selectRamButton (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =
-    let ramCount = List.length wsModel.RamComponents
+    let ramCount = List.length wsModel.RamComps
     let props, buttonFunc =
         if ramCount > 0 then
             selectRamButtonProps, (fun _ -> dispatch <| SetWSModel {wsModel with RamModalActive = true})
@@ -637,7 +637,7 @@ let selectRamModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElemen
                 hr []
                 Table.table [] [
                     tbody []
-                        (List.map (ramRows) wsModel.RamComponents)
+                        (List.map (ramRows) wsModel.RamComps)
                 ]
             ]
 
@@ -933,13 +933,18 @@ let wsClosedPane (model: Model) (dispatch: Msg -> unit) : ReactElement =
             List.filter (fun (comp: Component) -> match comp.Type with | RAM1 _ -> true | _ -> false) comps
             |> List.sortBy (fun ram -> ram.Label)
 
+        let ramCompIds = List.map (fun (ram: Component) -> ComponentId ram.Id) ramComps
+
         let selectedWaves = List.filter (fun key -> Map.containsKey key allWaves) wsModel.SelectedWaves
+        let selectedRams = Map.filter (fun ramId _ -> List.contains ramId ramCompIds) wsModel.SelectedRams
+
         let wsModel = {
             wsModel with
                 State = WSOpen
                 AllWaves = allWaves
                 SelectedWaves = selectedWaves
-                RamComponents = ramComps
+                RamComps = ramComps
+                SelectedRams = selectedRams
                 FastSim = simData.FastSim
         }
 


### PR DESCRIPTION
When starting the wave simulator, selected rams are now checked to ensure they actually exist.

This PR also adds in a new message which resets the `WaveSim` and `WaveSimSheet` fields in the `Model`.