### PR TITLE
Change behaviour when hovering over wave labels

### DIFF
--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -165,6 +165,7 @@ type WaveSimModel = {
     SelectedRams: Map<ComponentId, string>
     FastSim: FastSimulation
     SearchString: string
+    HoveredLabel: WaveIndexT option
 }
 
 /// TODO: Decide a better number then move to Constants module.
@@ -188,6 +189,7 @@ let initWSModel : WaveSimModel = {
     SelectedRams = Map.empty
     FastSim = FastCreate.emptyFastSimulation ()
     SearchString = ""
+    HoveredLabel = None
 }
 
 type DiagEl = | Comp of Component | Conn of Connection

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -137,6 +137,8 @@ type Wave = {
     // unique within design sheet (SheetId)
     // [] for top-level waveform: path to sheet
     SheetId: ComponentId list
+    // Wires connected to this waveform
+    Conns: ConnectionId list
     // This is used to key the AllWaves map, since this is guaranteed to be unique.
     Driver: DriverT
     DisplayName: string

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -834,10 +834,9 @@ let nameRows (wsModel: WaveSimModel) dispatch: ReactElement list =
                 OnMouseOut (fun _ -> dispatch <| SetWSModel {wsModel with HoveredLabel = None} )
             ]
         ] [
-            Level.left [
-                Props (nameRowLevelLeftProps visibility)
-            ] [
-                Delete.delete [
+            Level.left
+                [ Props (nameRowLevelLeftProps visibility) ]
+                [ Delete.delete [
                     Delete.Option.Size IsSmall
                     Delete.Option.Props [
                         OnClick (fun _ ->
@@ -845,9 +844,11 @@ let nameRows (wsModel: WaveSimModel) dispatch: ReactElement list =
                             dispatch <| SetWSModel {wsModel with SelectedWaves = selectedWaves}
                         )
                     ]
-                ] []
-            ]
-            Level.right [] [ label [] [ str wave.DisplayName ] ]
+                  ] []
+                ]
+            Level.right
+                [ Props [ Style [ PaddingRight Constants.labelPadding ] ] ]
+                [ label [] [ str wave.DisplayName ] ]
         ]
     )
 
@@ -868,7 +869,7 @@ let valueRows (wsModel: WaveSimModel) =
     selectedWaves wsModel
     |> List.map (getWaveValue wsModel.CurrClkCycle)
     |> List.map (valToString wsModel.Radix)
-    |> List.map (fun value -> label [ labelStyle ] [ str value ])
+    |> List.map (fun value -> label [ valueLabelStyle ] [ str value ])
 
 /// Create column of waveform values
 let private valuesColumn wsModel : ReactElement =

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -304,6 +304,14 @@ let labelStyle = Style [
     BorderBottom "1px solid rgb(219,219,219)"
 ]
 
+let nameRowLevelLeftProps (visibility: string): IHTMLProp list = [
+    Style [
+        Position PositionOptions.Sticky
+        Left 0
+        Visibility visibility
+    ]
+]
+
 let ramRowStyle = Style [
     Height Constants.rowHeight
 ]

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -27,6 +27,9 @@ module Constants =
     let valueOnWaveText = { DrawHelpers.defaultText with FontSize = fontSizeValueOnWave }
     let valueOnWavePadding = 150.0
 
+    let borderProperties = "2px solid rgb(219,219,219)"
+
+
 let topRowStyle = Style [
     Height Constants.rowHeight
     BorderBottom "2px solid rgb(219,219,219)"
@@ -316,17 +319,10 @@ let ramRowStyle = Style [
     Height Constants.rowHeight
 ]
 
-let borderProperties = "2px solid rgb(219,219,219)"
-
-let colWidth width =
-    match width with
-    | Some x -> string x
-    | None -> "100%"
-
 let waveSimColumn = [
     Height "100%"
     Width "100%"
-    BorderTop borderProperties
+    BorderTop Constants.borderProperties
     Display DisplayOptions.Grid
     GridAutoRows Constants.rowHeight
     FontSize "12px"
@@ -339,7 +335,7 @@ let namesColumnStyle = Style (
     (waveSimColumn) @ [
         MinWidth Constants.namesColWidth
         Float FloatOptions.Left
-        BorderRight borderProperties
+        BorderRight Constants.borderProperties
         GridColumnStart 1
         TextAlign TextAlignOptions.Right
     ])
@@ -348,7 +344,7 @@ let valuesColumnStyle = Style (
     (waveSimColumn) @ [
         MinWidth Constants.valuesColWidth
         Float FloatOptions.Right
-        BorderLeft borderProperties
+        BorderLeft Constants.borderProperties
         GridColumnStart 3
     ])
 
@@ -363,7 +359,7 @@ let waveRowsStyle width = Style [
     Display DisplayOptions.Grid
     FontSize "12px"
     GridAutoRows Constants.rowHeight
-    BorderTop borderProperties
+    BorderTop Constants.borderProperties
     Width width
     GridColumnStart 1
     GridRowStart 1
@@ -390,17 +386,16 @@ let clkLineStyle = Style [
     StrokeWidth Constants.clkLineWidth
 ]
 
-let clkCycleText m i : IProp list =
-    [
-        SVGAttr.FontSize "12px"
-        SVGAttr.TextAnchor "middle"
-        X (singleWaveWidth m * (float i + 0.5))
-        Y (0.6 * Constants.viewBoxHeight)
-    ]
+let clkCycleText m i : IProp list = [
+    SVGAttr.FontSize "12px"
+    SVGAttr.TextAnchor "middle"
+    X (singleWaveWidth m * (float i + 0.5))
+    Y (0.6 * Constants.viewBoxHeight)
+]
 
 let clkCycleSVGStyle = Style [
     Display DisplayOptions.Block
-    BorderBottom borderProperties
+    BorderBottom Constants.borderProperties
 ]
 
 let waveformColumnRowProps m : IProp list = [

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -29,6 +29,7 @@ module Constants =
 
     let borderProperties = "2px solid rgb(219,219,219)"
 
+    let labelPadding = 3
 
 let topRowStyle = Style [
     Height Constants.rowHeight
@@ -303,6 +304,12 @@ let upDownButtonStyle = Style [
 ]
 
 let labelStyle = Style [
+    Height Constants.rowHeight
+    BorderBottom "1px solid rgb(219,219,219)"
+]
+
+let valueLabelStyle = Style [
+    PaddingLeft Constants.labelPadding
     Height Constants.rowHeight
     BorderBottom "1px solid rgb(219,219,219)"
 ]


### PR DESCRIPTION
This PR adds new functionality when hovering over wave labels in the waveform simulator.

Components and the relevant connections are highlighted when hovering over the corresponding waveform label in the waveform viewer.

When hovering over a waveform label, a cross button will appear. Clicking on that cross button will remove that wave from the waveform viewer.

Closes https://github.com/jzzheng22/issie/issues/32
Closes https://github.com/jzzheng22/issie/issues/39
Closes https://github.com/jzzheng22/issie/issues/44