### PR TITLE
Reorder waves by dragging and dropping into desired order

### DIFF
--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -168,6 +168,8 @@ type WaveSimModel = {
     FastSim: FastSimulation
     SearchString: string
     HoveredLabel: WaveIndexT option
+    DraggedIndex: WaveIndexT option
+    PrevSelectedWaves: WaveIndexT list option
 }
 
 /// TODO: Decide a better number then move to Constants module.
@@ -192,6 +194,8 @@ let initWSModel : WaveSimModel = {
     FastSim = FastCreate.emptyFastSimulation ()
     SearchString = ""
     HoveredLabel = None
+    DraggedIndex = None
+    PrevSelectedWaves = None
 }
 
 type DiagEl = | Comp of Component | Conn of Connection

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -875,7 +875,7 @@ let nameRows (wsModel: WaveSimModel) dispatch: ReactElement list =
 let namesColumn wsModel dispatch : ReactElement =
     let rows = nameRows wsModel dispatch
 
-    div [ namesColumnStyle ]
+    div namesColumnProps
         (List.concat [ topRow; rows ])
 
 /// Create label of waveform value for each selected wave at a given clk cycle.

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -973,9 +973,7 @@ let wsClosedPane (model: Model) (dispatch: Msg -> unit) : ReactElement =
 
         let wsSheet = Option.get (getCurrFile model)
         let wsModel = getWSModel model
-        let allWaves =
-            getWaves simData (comps, conns)
-            |> Map.map (generateWaveform wsModel)
+        let allWaves = getWaves simData (comps, conns)
 
         let ramComps =
             List.filter (fun (comp: Component) -> match comp.Type with | RAM1 _ -> true | _ -> false) comps

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -303,37 +303,23 @@ let upDownButtonStyle = Style [
     BorderRadius 0
 ]
 
-
-
-let labelStyle = Style [
+let nameRowLevelStyle isHovered = Style [
     Height Constants.rowHeight
     BorderBottom "1px solid rgb(219,219,219)"
+    if isHovered then
+        BackgroundColor "hsl(0, 0%, 96%)"
+        Cursor "grab"
+]
+
+let nameLabelStyle isHovered = Style [
+    if isHovered then
+        Cursor "grab"
 ]
 
 let valueLabelStyle = Style [
+    Height Constants.rowHeight
+    BorderBottom "1px solid rgb(219,219,219)"
     PaddingLeft Constants.labelPadding
-]
-
-let nameProps : IHTMLProp list = [
-    labelStyle
-    Draggable true
-    OnDrop (fun ev ->
-        
-        let nameColEl = Browser.Dom.document.getElementById "namesColumn"
-        let bcr = nameColEl.getBoundingClientRect ()
-        printf "bcr.left: %A" bcr.left
-        printf "bcr.right: %A" bcr.right
-        printf "bcr.top: %A" bcr.top
-        printf "bcr.bottom: %A" bcr.bottom
-        printf "bcr.height: %A" bcr.height
-        printf "bcr.width: %A" bcr.width
-
-        printf "ev.clientX: %A" ev.clientX
-        printf "ev.clientY: %A" ev.clientY
-
-
-
-    )
 ]
 
 let nameRowLevelLeftProps (visibility: string): IHTMLProp list = [

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -303,6 +303,8 @@ let upDownButtonStyle = Style [
     BorderRadius 0
 ]
 
+
+
 let labelStyle = Style [
     Height Constants.rowHeight
     BorderBottom "1px solid rgb(219,219,219)"
@@ -310,8 +312,28 @@ let labelStyle = Style [
 
 let valueLabelStyle = Style [
     PaddingLeft Constants.labelPadding
-    Height Constants.rowHeight
-    BorderBottom "1px solid rgb(219,219,219)"
+]
+
+let nameProps : IHTMLProp list = [
+    labelStyle
+    Draggable true
+    OnDrop (fun ev ->
+        
+        let nameColEl = Browser.Dom.document.getElementById "namesColumn"
+        let bcr = nameColEl.getBoundingClientRect ()
+        printf "bcr.left: %A" bcr.left
+        printf "bcr.right: %A" bcr.right
+        printf "bcr.top: %A" bcr.top
+        printf "bcr.bottom: %A" bcr.bottom
+        printf "bcr.height: %A" bcr.height
+        printf "bcr.width: %A" bcr.width
+
+        printf "ev.clientX: %A" ev.clientX
+        printf "ev.clientY: %A" ev.clientY
+
+
+
+    )
 ]
 
 let nameRowLevelLeftProps (visibility: string): IHTMLProp list = [
@@ -324,6 +346,7 @@ let nameRowLevelLeftProps (visibility: string): IHTMLProp list = [
 
 let ramRowStyle = Style [
     Height Constants.rowHeight
+    BorderBottom "1px solid rgb(219,219,219)"
 ]
 
 let waveSimColumn = [
@@ -346,6 +369,11 @@ let namesColumnStyle = Style (
         GridColumnStart 1
         TextAlign TextAlignOptions.Right
     ])
+
+let namesColumnProps : IHTMLProp list = [
+    Id "namesColumn"
+    namesColumnStyle
+]
 
 let valuesColumnStyle = Style (
     (waveSimColumn) @ [


### PR DESCRIPTION
This PR adds support for users to reorder waveforms in the wave viewer by dragging and dropping wave labels into the desired order.

There is a visual feedback to make this more intuitive:

- The cursor changes to a 'grab' icon when hovering over a wave label, to indicate that the label can be dragged
- If the user moves the label outside of the boundaries of the wave label column, the label returns to its original position.