### PR TITLE
Improvements

### DIFF
--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -157,7 +157,7 @@ type Wave = {
     // Map keyed by clock cycle
     WaveValues: WireData list
     // Store SVG cache here maybe?
-    Polylines: ReactElement list option
+    SVG: ReactElement option
 }
 
 type WaveSimModel = {

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -130,6 +130,8 @@ type WaveSimState =
     | SimError of SimulationError
     /// If there is no sequential (clocked) logic in the circuit
     | NonSequential
+    /// While waiting for the fast simulator to finish running
+    | Loading
     /// If there are no errors in the circuit diagram
     | Success
 
@@ -247,6 +249,7 @@ type Msg =
     | SetWSModel of WaveSimModel
     | SetWSModelAndSheet of WaveSimModel * string
     | InitiateWaveSimulation of WaveSimModel
+    | RefreshWaveSim of WaveSimModel * SimulationData * CanvasState * (Msg -> unit)
     | SetSimulationGraph of SimulationGraph  * FastSimulation
     | SetSimulationBase of NumberBase
     | IncrementSimulationClockTick of int

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -336,13 +336,15 @@ let update (msg : Msg) oldModel =
         {model with LastUsedDialogWidth=width}, Cmd.none
     | StartSimulation simData -> 
         { model with CurrentStepSimulationStep = Some simData }, Cmd.none
-    | SetWSModel wsModel -> 
+    | SetWSModel wsModel ->
         setWSModel wsModel model, Cmd.none
     | SetWSModelAndSheet (wsModel, wsSheet) ->
-        let newModel = 
+        let newModel =
             {model with WaveSimSheet = wsSheet}
             |> setWSModel wsModel
         newModel, Cmd.none
+    | RefreshWaveSim (wsModel, simData, canvState, dispatch) ->
+        model, Cmd.OfAsync.perform WaveSim.refreshWaveSim (wsModel, simData, canvState) SetWSModel
     | AddWSModel (sheet, wsModel) ->
         { model with 
             WaveSim = Map.add sheet wsModel model.WaveSim

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -337,7 +337,6 @@ let update (msg : Msg) oldModel =
     | StartSimulation simData -> 
         { model with CurrentStepSimulationStep = Some simData }, Cmd.none
     | SetWSModel wsModel -> 
-        printf "SetWSModel"
         setWSModel wsModel model, Cmd.none
     | SetWSModelAndSheet (wsModel, wsSheet) ->
         let newModel = 
@@ -349,7 +348,6 @@ let update (msg : Msg) oldModel =
             WaveSim = Map.add sheet wsModel model.WaveSim
         }, Cmd.none
     | InitiateWaveSimulation wsModel ->
-        printf "InitiateWaveSimulation"
         let allWaves = Map.map (WaveSim.generateWaveform wsModel) wsModel.AllWaves
         let wsModel' = {wsModel with AllWaves = allWaves}
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -63,8 +63,6 @@ let displayValuesOnWave wsModel (waveValues: WireData list) (transitions: NonBin
 /// Generates the polyline(s) for a specific waveform
 let generateWaveform (wsModel: WaveSimModel) (index: WaveIndexT) (wave: Wave): Wave =
     if List.contains index wsModel.SelectedWaves then
-        // let waveName = wave.DisplayName
-        // printf "generating wave for %A" waveName
         let waveform =
             match wave.Width with
             | 0 -> failwithf "Cannot have wave of width 0"
@@ -662,7 +660,6 @@ let private setClkCycle (wsModel: WaveSimModel) (dispatch: Msg -> unit) (newClkC
 
     if newClkCycle <= endCycle wsModel then
         if newClkCycle < wsModel.StartCycle then
-            printf "StartCycle: %A" newClkCycle
             dispatch <| InitiateWaveSimulation
                 {wsModel with 
                     StartCycle = newClkCycle
@@ -676,8 +673,6 @@ let private setClkCycle (wsModel: WaveSimModel) (dispatch: Msg -> unit) (newClkC
                     ClkCycleBoxIsEmpty = false
                 }
     else
-        printf "StartCycle: %A" (newClkCycle - (wsModel.ShownCycles - 1))
-        printf "CurrClkCycle: %A" newClkCycle
         dispatch <| InitiateWaveSimulation
             {wsModel with
                 StartCycle = newClkCycle - (wsModel.ShownCycles - 1)

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -525,3 +525,9 @@ let refreshSvg =
                 ]
             ] []
         ]
+
+let emptyRefreshSVG =
+    svg [
+        SVGAttr.Height "30"
+        SVGAttr.Width "30"
+    ] []

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -15,7 +15,7 @@ module Constants =
     let rightMargin = 50
 
     let rowHeight = 30
-    let clkLineWidth = 0.4
+    let clkLineWidth = 0.8
     let lineThickness : float = 0.8
 
     let fontSizeValueOnWave = "10px"
@@ -414,6 +414,18 @@ let waveRowProps m : IProp list =
     waveRowSVGStyle
 ]
 
+let backgroundSVG (wsModel: WaveSimModel) count : ReactElement list =
+    let clkLine x = 
+        line [
+            clkLineStyle
+            X1 x
+            Y1 0.0
+            X2 x
+            Y2 (Constants.viewBoxHeight * float (count + 1))
+        ] []
+    [ wsModel.StartCycle + 1 .. endCycle wsModel + 1 ] 
+    |> List.map (fun x -> clkLine (float x * singleWaveWidth wsModel))
+
 /// Controls the background highlighting of which clock cycle is selected
 let clkCycleHighlightSVG m dispatch =
     let count = List.length m.SelectedWaves
@@ -439,13 +451,17 @@ let clkCycleHighlightSVG m dispatch =
             let cycle = (int <| (ev.clientX - bcr.left) / singleWaveWidth m) + m.StartCycle
             dispatch <| SetWSModel {m with CurrClkCycle = cycle}
         )
-    ] [
-        rect [
-            SVGAttr.Width (singleWaveWidth m)
-            SVGAttr.Height "100%"
-            X (float m.CurrClkCycle * (singleWaveWidth m))
-        ] []
-    ]
+        ]
+        (List.append 
+            [
+                rect [
+                    SVGAttr.Width (singleWaveWidth m)
+                    SVGAttr.Height "100%"
+                    X (float m.CurrClkCycle * (singleWaveWidth m))
+                ] []
+            ]
+            (backgroundSVG m count)
+        )
 
 
 let radixTabProps : IHTMLProp list = [


### PR DESCRIPTION
This PR includes several relatively small changes to improve the waveform simulator:

1. The lines which denote each clock cycle are now generated with the highlight rect svg instead of for each wave at each clock cycle. Should be very marginally faster.
2. Non-existent components and connections are filtered out before highlight message is sent: this reduces the likelihood of an exception.
3. A significant improvement in speed: only display rows in RAM table when they have been explicitly initialised with a value.
4. Use of async code to show a loading state! This gives feedback to user when the fast sim takes a while to load.