### PR TITLE
Generate waves on resize of wave sim viewer width

### DIFF
--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -248,7 +248,7 @@ let displayView model dispatch =
                 ShownCycles = wholeCycles
                 WaveformColumnWidth = wholeCycleWidth
             }
-        dispatch <| SetWSModel wsModel
+        dispatch <| InitiateWaveSimulation wsModel
         dispatch <| SetViewerWidth viewerWidth
 
     let inline processAppClick topMenu dispatch (ev: Browser.Types.MouseEvent) =

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -1106,7 +1106,7 @@ let refreshButtonAction model dispatch = fun _ ->
     | None ->
         dispatch <| SetWSModel { wsModel with State = NoProject }
     | Some (Error e, _) ->
-        dispatch <| SetWSModel { wsModel with State = SimError e }
+        dispatch <| SetWSModelAndSheet ({ wsModel with State = SimError e }, wsSheet)
     | Some (Ok simData, canvState) ->
         if simData.IsSynchronous then
             let wsModel = { wsModel with State = Loading }
@@ -1114,7 +1114,7 @@ let refreshButtonAction model dispatch = fun _ ->
             dispatch <| RefreshWaveSim (wsModel, simData, canvState)
 
         else
-            dispatch <| SetWSModel { wsModel with State = NonSequential }
+            dispatch <| SetWSModelAndSheet ({ wsModel with State = NonSequential }, wsSheet)
 
 /// ReactElement showing instructions and wave sim buttons
 let topHalf (model: Model) dispatch : ReactElement =


### PR DESCRIPTION
This PR fixes two bugs:

1. When changing the width of the wave sim pane, waves are now generated for clock cycles that weren't originally visible.
2. The WaveSimSheet is now set for all cases where the refresh button is clicked, EXCEPT for when no project is open. Not sure if this case can ever occur anyway...