### PR TITLE
Various code improvements for waveform simulator

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -561,11 +561,6 @@ module CommonTypes
 
     (*---------------------------Types for wave Simulation----------------------------------------*)
 
-    
-    type MoreWaveData =
-        | RamWaveData of addr: uint32 * ramPath: ComponentId list * label:string
-        | ExtraData of ramPath: ComponentId list * label:string
-        
     // The "NetList" types contain all the circuit from Diagram in an abstracted form that
     // removed layout info and connections as separate entities. However, connection Ids are
     // available as fileds in components for interface to the Diagram conmponents

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -84,7 +84,6 @@ let init() = {
         Int2 = None
         MemorySetup = None
         MemoryEditorData = None
-        WaveSetup = None
         Progress = None
     }
     Notifications = {

--- a/src/Renderer/UI/ModelType.fs
+++ b/src/Renderer/UI/ModelType.fs
@@ -39,19 +39,6 @@ type MemoryEditorData = {
     NumberBase : NumberBase
 }
 
-
-type SheetWave = {
-    // path to sheet from simulation graph root
-    Path: ComponentId list
-    Sheet: string
-    CSort: string
-    Label: string
-    }
-
-
-type MoreWaveSetup = SheetWave list * Set<ComponentId list>
-   
-
 /// Possible fields that may (or may not) be used in a dialog popup.
 type PopupDialogData = {
     Text : string option;
@@ -60,7 +47,6 @@ type PopupDialogData = {
     ProjectPath: string
     MemorySetup : (int * int * InitMemData * string option) option // AddressWidth, WordWidth. 
     MemoryEditorData : MemoryEditorData option // For memory editor and viewer.
-    WaveSetup: MoreWaveSetup option
     Progress: PopupProgress option
 }
 
@@ -86,46 +72,10 @@ type UICommandType =
     | StartWaveSim
     | ViewWaveSim
     | CloseWaveSim
-    
 
 //---------------------------------------------------------------
 //---------------------WaveSim types-----------------------------
 //---------------------------------------------------------------
-
-(*
-WaveSim state.
-
-Principles: 
-1) at any time wavesim simulates a stored model.LastSimulatedCanvas circuit which is guaranteed working if it exists 
-2) pressing "simulate button" updates this circuit
-3) wavesim has two views: editor and waveforms. each waveform is the signal on a NetGroup (set of connections from one driver to multiple inputs).
-4) waveforms display view based on: selected waveforms, zoom, cursor position, etc
-5) simulation is rerun automatically as needed to generate current display
-6) editor view interfaces with current circuit, colouring selected nets green, and allowing selection on nets to determine
-default selected waveforms. If current circuit has changed only driving components still on circuit can be used this way.
-7) simulate button color determines status; if circuit has chnaged from that simulated it will be orange (errors) or green (OK to rerun simulation).
-8) list of currently displayed ports is held in state and saved / restored with each sheet. LastSimulatedCanvas (and simulation data) are not saved/restored but
-are recalculated when needed. List of possible to display ports used by waveadder
-
-Data structures for internal state
-
-SimParams: parameters that can be changed during simulation of one ckt that affect what is displayed.
-
-*)
-
-
-
-type WaveName = string
-
-type Wire = {
-    NBits: uint32
-    BitData: bigint 
-}
-
-type StateSample = string array
-type Sample = | Wire of Wire | StateSample of StateSample
-type SimTime = Sample array
-type Waveform = Sample array
 
 /// Determines whether the user is able to see the wave viewer pane.
 /// Changes value depending on the state of the circuit and whether
@@ -318,7 +268,6 @@ type Msg =
     | SetPropertiesExtraDialogText of string option
     | SetPopupDialogMemorySetup of (int * int * InitMemData * string option) option
     | SetPopupMemoryEditorData of MemoryEditorData option
-    | SetPopupWaveSetup of MoreWaveSetup
     | SetPopupProgress of PopupProgress option
     | UpdatePopupProgress of (PopupProgress -> PopupProgress)
     | SimulateWithProgressBar of SimulationProgress

--- a/src/Renderer/UI/PopupView.fs
+++ b/src/Renderer/UI/PopupView.fs
@@ -170,15 +170,6 @@ let private buildPopup title body foot close extraStyle =
             ]
         ]
 
-
-
-let showWaveSetupPopup maybeTitle (popupBody: MoreWaveSetup option ->ReactElement) maybeFoot extraStyle dispatch =
-    fun _ (dialogData:PopupDialogData)->
-        printfn "starting morewavesetup popup function"
-        unclosablePopup maybeTitle (popupBody dialogData.WaveSetup) maybeFoot extraStyle dispatch
-    |> ShowPopup |> dispatch
-
-
 /// Body and foot are functions that take a string of text and produce a
 /// reactElement. The meaning of the input string to those functions is the
 /// content of PopupDialogText (i.e. in a dialog popup, the string is the

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -430,8 +430,6 @@ let update (msg : Msg) oldModel =
         }, Cmd.none
     | SetPopupDialogMemorySetup m ->
         { model with PopupDialogData = {model.PopupDialogData with MemorySetup = m} }, Cmd.none
-    | SetPopupWaveSetup m ->
-        { model with PopupDialogData = {model.PopupDialogData with WaveSetup = Some m} }, Cmd.none
     | SetPopupMemoryEditorData m ->
         { model with PopupDialogData = {model.PopupDialogData with MemoryEditorData = m} }, Cmd.none
     | SetPopupProgress progOpt ->

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -350,10 +350,15 @@ let update (msg : Msg) oldModel =
             WaveSim = Map.add sheet wsModel model.WaveSim
         }, Cmd.none
     | InitiateWaveSimulation wsModel ->
-        let allWaves = Map.map (WaveSim.generateWaveform wsModel) wsModel.AllWaves
+        let start = TimeHelpers.getTimeMs ()
+        let allWaves =
+            Map.map (WaveSim.generateWaveform wsModel) wsModel.AllWaves
+            |> TimeHelpers.instrumentInterval "InitiateWaveSimulation generateWaveform" start
+
         let wsModel' = {wsModel with AllWaves = allWaves}
 
         setWSModel wsModel' model, Cmd.ofMsg (Sheet(SheetT.SetSpinner false))
+
     | SetSimulationGraph (graph, fastSim) ->
         let simData = getSimulationDataOrFail model "SetSimulationGraph"
         { model with CurrentStepSimulationStep = { simData with Graph = graph ; FastSim = fastSim} |> Ok |> Some }, Cmd.none

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -629,7 +629,7 @@ let toggleRamSelection (ramId: ComponentId) (ramLabel: string) (wsModel: WaveSim
             Map.remove ramId wsModel.SelectedRams
         else
             Map.add ramId ramLabel wsModel.SelectedRams
-    dispatch <| InitiateWaveSimulation {wsModel with SelectedRams = selectedRams}
+    dispatch <| SetWSModel {wsModel with SelectedRams = selectedRams}
 
 /// Modal that, when active, allows users to select RAMs to view their contents.
 let selectRamModal (wsModel: WaveSimModel) (dispatch: Msg -> unit) : ReactElement =

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -451,7 +451,7 @@ let toggleSelectSubGroup (wsModel: WaveSimModel) dispatch (selected: bool) (wave
         if selected then
             List.append wsModel.SelectedWaves waves
         else
-            List.except wsModel.SelectedWaves waves
+            List.except waves wsModel.SelectedWaves
     dispatch <| InitiateWaveSimulation {wsModel with SelectedWaves = selectedWaves}
 
 /// Table row of a checkbox and name of a wave.


### PR DESCRIPTION
This PR does four things:

1. Removes dead code which is no longer necessary.
2. Fixes a bug where deselecting a subgroup deselected all waves.
3. Changes RAM tables to dispatch a SetWSModel message instead of InitiateWaveSimulation message
4. Adds instrumentation code