### PR TITLE
Added test script for IssieStick debugger

### DIFF
--- a/Tests/hw/IS-uart.js
+++ b/Tests/hw/IS-uart.js
@@ -1,3 +1,15 @@
+//  IssieStick debugger test script
+//    This script tests the debugger functionality of Issie hardware by reading the value of a specified viewer.
+//    It works with Issie designs built in debug mode and loaded onto an IceStick or IssieStick with a FT2232H USB interface.
+//    
+//    Usage: node Tests\hw\IS-uart.js <Viewer Index>
+//      <Viewer Index> is the 8-bit reference assigned to a viewer during compilation.
+//      The index of the first viewer is the character "0" (0x30)
+//    
+//    Prerequisites:
+//      - IceStick or IssieStick with a FT2232H USB interface
+//      - Issie design with at least one viewer, built in debug mode and loaded onto the stick
+
 import { WebUSB } from 'usb';
 
 //USB device settings for FT2232H channel B

--- a/Tests/hw/IS-uart.js
+++ b/Tests/hw/IS-uart.js
@@ -1,0 +1,117 @@
+import { WebUSB } from 'usb';
+
+//USB device settings for FT2232H channel B
+const VID = 0x0403; //0x0403 = 1027
+const PID = 0x6010; //0x6010 = 24592
+const DEVICE_IF = 1;   
+const TX_EP = 4;
+const RX_EP = 3;
+
+//UART speed 115200bps
+//const BAUD_VALUE = 49256;
+//const BAUD_INDEX = 514;
+
+//UART speed 9600bps
+const BAUD_VALUE = 1250;
+const BAUD_INDEX = 514;
+
+const BAUD_REQ = 3; //Control request number to set baud
+
+const RX_BUF_SIZE = 64;
+const RX_PAD_BYTES = 2; //Extra bytes prefixing every transfer in
+
+const TX_CONTINUE = "C"; //Message to start clock
+const TX_READ = "R";  //Message to read viewer 0
+const DEFAULT_VIEWER = "0";
+const TX_INTERVAL = 500;
+
+var device
+var sendTimer
+var kill = false
+var viewIndex
+
+if (process.argv.length < 3) {
+    console.log("Using default viewer index");
+    viewIndex = DEFAULT_VIEWER;
+} else {
+    viewIndex = process.argv[2];
+}
+
+//Terminate on Ctrl+C
+process.on('SIGINT', async function() {
+    clearInterval(sendTimer);
+    kill = true;
+});
+
+//Receive thread
+async function readLoop() {
+    const decoder = new TextDecoder();
+    while (device.opened && !kill) {
+        var result = await device.transferIn(RX_EP, RX_BUF_SIZE);
+        if (result.data.byteLength > RX_PAD_BYTES) {
+            //var message = decoder.decode(result.data.buffer.slice(RX_PAD_BYTES)); //Format input as string
+            var message = Buffer.from(result.data.buffer.slice(RX_PAD_BYTES)).toString('hex');   //Format input as hex
+            console.log(`Received message: ${message}`);
+        }
+    }
+}
+
+//Main thread
+(async () => {
+
+    const customWebUSB = new WebUSB({
+        // Bypass cheking for authorised devices
+        allowAllDevices: true
+    });
+
+    //Find device with correct VID and PID
+    try {
+        device = await customWebUSB.requestDevice({
+            filters: [{
+                vendorId: VID,
+                productId: PID
+            }]
+        });
+    }
+    catch(err) {
+        throw new Error("IceStick or IssieStick device (FT2232H) not found");
+    }
+
+    if (device) {
+        console.log(`Found ${device.productName} (${device.vendorId},${device.productId})`);
+    }
+    
+    //Open and configure device
+    await device.open();
+    console.log('Opened:', device.opened);
+
+    await device.claimInterface(DEVICE_IF);
+
+    const result = await device.controlTransferOut({
+        requestType: 'vendor',
+        recipient: 'device',
+        request: BAUD_REQ,
+        value: BAUD_VALUE,
+        index: BAUD_INDEX,
+    });
+
+    console.log(`Set baud = ${result.status}`)
+
+    //Send Clock Continue Message
+    await device.transferOut(TX_EP, TX_CONTINUE);
+
+    //Send regular Viewer Request messages
+    console.log(`Reading Viewer Index ${viewIndex}`)
+    sendTimer = setInterval(function(){device.transferOut(TX_EP, TX_READ + viewIndex)},TX_INTERVAL);
+    
+    //Start receiver
+    await readLoop();
+
+    //Disconnect
+    console.log("Stopping");
+    await device.close();
+    console.log('Opened:', device.opened);
+    process.exit();
+
+
+})();

--- a/Tests/hw/package.json
+++ b/Tests/hw/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "dependencies": {
+      "usb": "^2.4.3"
+    }
+}

--- a/hdl/cores/LEDmatrix/LEDmatrix.v
+++ b/hdl/cores/LEDmatrix/LEDmatrix.v
@@ -1,0 +1,172 @@
+
+
+module LEDmatrix (clk,ramIn,wrAdd,we,colEn,sclk,sdo);
+    parameter PRESCALE = 6;
+    parameter COL_PAD = 8; //Extra prescaler cycles to add to column interval before sending row data
+    parameter COL_N = 16;
+    parameter ROW_N = 16;
+    parameter BLANK_PRE = 12;
+    parameter BLANK_POST = 12;
+    parameter BITS_PER_COL = 4;
+    parameter COLOURS = 3;
+
+    localparam DATA_W = BITS_PER_COL * COLOURS;
+    localparam SERIAL_W = ROW_N * COLOURS;
+    localparam COL_W = $clog2(COL_N);
+    localparam ROW_W = $clog2(ROW_N);
+    localparam ADD_W = COL_W + ROW_W;
+    
+    input clk;
+    input [DATA_W-1 : 0] ramIn;
+    input [ADD_W - 1 : 0] wrAdd;
+    input we;
+    output reg [COL_N-1:0] colEn = 0;
+    output reg sclk = 0;
+    output sdo;
+
+    reg[7:0] prescaler = 0;
+    reg[7:0] colTimer = 0;
+    reg[COL_W-1:0] colCount = 0;
+    reg[ROW_W-1:0] rowCount = 0;
+    reg[COLOURS-1:0] rgbCycle = 3'b100;
+    reg[7:0] blankCount = 0;
+    reg[BITS_PER_COL-1:0] value, pwmRef;
+    reg[BITS_PER_COL-1:0] frCount = 0;
+    wire sclk_int;
+    wire ps_out;
+    wire [DATA_W-1:0] ramOut;
+    wire [ADD_W-1:0] rdAdd;
+    integer i;
+
+    //Video RAM
+    VRAM #(.D_WIDTH(DATA_W), .A_WIDTH(ADD_W)) vram (.q(ramOut), .ra(rdAdd), .wa(wrAdd), .d(ramIn), .we(we), .clk(clk));
+
+    //Prescaler
+    assign ps_out = (prescaler == 0);
+    always@(posedge clk) begin
+        if (ps_out)
+            prescaler <= PRESCALE - 1;
+        else
+            prescaler <= prescaler - 1;
+    end
+
+    //Column Timer
+    assign colAdv = (colTimer == 0);
+    always@(posedge clk) begin
+        if (ps_out)
+            if (colAdv)
+                colTimer <= COL_PAD + SERIAL_W * 2 - 1;
+            else
+                colTimer <= colTimer - 1;
+    end
+
+    //Column Counter
+    assign frAdv = (colCount == 0);
+    always@(posedge clk) begin
+        if (ps_out && colAdv)
+            if (frAdv) begin
+                colCount <= COL_N - 1;
+                frCount <= frCount + 1;
+            end
+            else
+                colCount <= colCount - 1;
+    end
+
+    //Column select, latch and blanking
+    always@(posedge clk) begin
+        if (ps_out && colAdv)
+            blankCount <= BLANK_PRE + BLANK_POST - 1;
+        else if (blankCount != 0)
+            blankCount <= blankCount - 1;
+        
+        if (blankCount == BLANK_POST)
+            for (i = 0; i < COL_N; i = i + 1) //Loop creates a line decoder
+                colEn[i] <= (colCount == i);
+    end
+    assign blank = (blankCount != 0);
+    assign lat = blank;
+
+    //Serial output
+    always@(posedge clk) begin
+        
+        // Serial Idle until final ROW_N * 3 * 2 prescaler cycles of each column
+        if (colTimer > ROW_N * COLOURS * 2) begin
+            sclk <= 1'b0;
+            rgbCycle = 1 << COLOURS - 1;
+            rowCount = ROW_N-1;
+        end
+        // Run serial for final cycles
+        else if (colTimer && ps_out) begin
+            //Data update on serial clock falling edge
+            if (colTimer[0]) begin
+                //Cycle colours, increment row after last colour
+                rgbCycle <= {rgbCycle[0], rgbCycle[COLOURS-1 : 1]};
+                if (rgbCycle[0])
+                    rowCount <= rowCount - 1;
+                sclk <= 0;
+            end
+            else begin
+                sclk <= 1;
+            end
+        end
+            
+    end
+
+    //Generate PWM reference by reversing LSBs of frame count
+    integer j;
+    always @(*) begin
+        for (j = 0; j < BITS_PER_COL; j = j + 1)
+            pwmRef[j] = frCount[BITS_PER_COL - 1 - j];
+    end
+
+    //Pixel Lookup
+    assign rdAdd = {rowCount,colCount};
+    integer q;
+    //Select bits of VRAM output depending on which colour is transmitted next
+    always @(*) begin
+        value <= ramOut[BITS_PER_COL - 1 : 0];
+        for (q = 0; q < COLOURS; q = q + 1) //Loop + if creates a multiplexer
+            if (rgbCycle[q])
+                value <= ramOut[BITS_PER_COL*q +: BITS_PER_COL];
+    end
+
+    //Generate serial output from PWM comparator
+    assign sdo = (value > pwmRef);
+
+
+
+endmodule
+
+module VRAM(q, ra, d, wa, we, clk);
+    parameter D_WIDTH = 12;
+    parameter A_WIDTH = 8;
+    output reg [D_WIDTH-1:0] q;
+    input [D_WIDTH-1:0] d;
+    input [A_WIDTH-1:0] ra;
+    input [A_WIDTH-1:0] wa;
+    input we, clk;
+    reg [D_WIDTH-1:0] ram [A_WIDTH-1:0];
+     always @(posedge clk) begin
+         if (we)
+             ram[wa] <= d;
+         q <= ram[ra];
+     end
+
+    integer i,j;
+    reg[3:0] red,grn,blu;
+    reg[7:0] add;
+    initial begin
+        $display("Initialising VRAM");
+        //$readmemh("disp_init.hex", ram);
+        for (i = 0; i < 256; i = i + 1)
+            ram[i] = 0;
+        // for (i = 0; i < 16; i = i + 1)
+        //     for (j = 0; j < 16; j = j + 1) begin
+        //         red = i+j;
+        //         grn = i+j+16/3;
+        //         blu = i+j+32/3;
+        //         add = i*16+j;
+        //         ram[add] = {grn,blu,red};
+        //     end
+    end
+endmodule

--- a/hdl/cores/LEDmatrix/LEDmatrix_tb.v
+++ b/hdl/cores/LEDmatrix/LEDmatrix_tb.v
@@ -1,0 +1,41 @@
+`timescale 1ns / 1ps
+`include "LEDmatrix.v"
+
+module tb_LEDmatrix(clk,sclk,colEn,sdo);
+
+    /* Clock simulation */
+    localparam clock_tick = 83;         // in nanoseconds
+
+    output reg clk;
+    output sclk,sdo;
+    output [15:0] colEn;
+
+    LEDmatrix uut(
+        .clk(clk),
+        .ramIn(12'b0),
+        .wrAdd(8'b0),
+        .we(1'b0),
+        .colEn(colEn),
+        .sclk(sclk),
+        .sdo(sdo)
+    );
+
+    //** Clock ****************************************************     
+    
+    always begin
+        clk = 0;
+        #(clock_tick/2);
+        clk = 1;
+        #(clock_tick/2);
+    end
+    
+    initial begin
+        $dumpfile("out.vcd");
+        $dumpvars(0,tb_LEDmatrix);
+        #(100000);
+             
+        $finish;
+  
+    end
+
+endmodule

--- a/hdl/issiestick-0.1-debug.pcf
+++ b/hdl/issiestick-0.1-debug.pcf
@@ -1,0 +1,34 @@
+# Generic iCEstick placement constraints file
+# From https://github.com/cyrozap/iCEstick-UART-Demo
+
+# D connector
+set_io D0 121
+set_io D13 142 #LED
+
+# FTDI Port B UART
+set_io DCDn 3
+set_io DSRn 4
+set_io DTRn 7
+set_io CTSn 8
+set_io RTSn 9
+set_io RS232_Tx_TTL 10
+set_io RS232_Rx_TTL 11
+
+# SPI
+set_io SPI_SCK 70
+set_io SPI_SI 68
+set_io SPI_SO 67
+set_io SPI_SS_B 71
+
+# Configuration pins
+set_io CDONE 65
+set_io CRESET_B 66
+
+# 12 MHz clock
+set_io debug_clk 52
+
+#Push buttons
+set_io PB0 56
+set_io PB1 60
+set_io PB2 61
+set_io PB3 62

--- a/hdl/issiestick-0.1.pcf
+++ b/hdl/issiestick-0.1.pcf
@@ -1,0 +1,34 @@
+# Generic iCEstick placement constraints file
+# From https://github.com/cyrozap/iCEstick-UART-Demo
+
+# D connector
+set_io D0 121
+set_io D13 142 #LED
+
+# FTDI Port B UART
+set_io DCDn 3
+set_io DSRn 4
+set_io DTRn 7
+set_io CTSn 8
+set_io RTSn 9
+set_io RS232_Tx_TTL 10
+set_io RS232_Rx_TTL 11
+
+# SPI
+set_io SPI_SCK 70
+set_io SPI_SI 68
+set_io SPI_SO 67
+set_io SPI_SS_B 71
+
+# Configuration pins
+set_io CDONE 65
+set_io CRESET_B 66
+
+# 12 MHz clock
+set_io clk 52
+
+#Push buttons
+set_io PB0 56
+set_io PB1 60
+set_io PB2 61
+set_io PB3 62


### PR DESCRIPTION
This script tests the debugger functionality of Issie hardware by reading the value of a specified viewer.
It works with Issie designs built in debug mode and loaded onto an IceStick or IssieStick with a FT2232H USB interface.

The script does not modify the Issie app and it is intended only to support development of the Issie debugger.

The existing debugger implementation in Issie uses file-based I/O to communicate with the hardware, which is not compatible with Windows when the USB drivers are loaded to support the iceprog programmer tool. This script uses the cross-platform [node-usb](https://node-usb.github.io/node-usb/) library instead.

Usage: `node Tests\hw\IS-uart.js [Viewer Index]`
  `[Viewer Index]` is the 8-bit reference assigned to a viewer during compilation.
  The index of the first viewer allocated by Issie is the character "0" (0x30)

Prerequisites:
 - usb module for node.js
 - IceStick or IssieStick with a FT2232H USB interface
 - Issie design with at least one viewer, built in debug mode and loaded onto the stick