### PR TITLE
Add JSONComponent module to CommonTypes

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,5 +2,5 @@
 cls
 dotnet tool restore
 dotnet paket install
-:: dotnet -v restore build.proj
+:: dotnet restore build.proj
 dotnet fsi build.fsx  %*

--- a/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
@@ -53,7 +53,7 @@ let changeLsbf (symModel:Model) (compId:ComponentId) (newLsb:int64) =
     let newcompotype = 
         match symbol.Component.Type with
         | BusSelection (w, _) -> BusSelection (w, int32(newLsb))
-        | BusCompare (w, _) -> BusCompare (w, uint32(newLsb)) 
+        | BusCompare (w, _) -> BusCompare (w, uint32(newLsb))
         | Constant1(w, _,txt) -> Constant1 (w, newLsb,txt)
         | _ -> failwithf "this shouldnt happen, incorrect call of message changeLsb"
 

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -563,6 +563,7 @@ let getLatestCanvas state =
         | CanvasWithFileWaveInfoAndNewConns(canvas, _, _) -> legacyTypesConvert canvas
         | NewCanvasWithFileWaveInfoAndNewConns(canvas,_,_) -> canvas
         | NewCanvasWithFileWaveSheetInfoAndNewConns (canvas,_,_,_) -> canvas
+    let comps = List.map convertFromJSONComponent comps
     List.map getLatestComp comps, conns
 
 


### PR DESCRIPTION
Use a sepaarte F# type JSONComponent to load/save JSON definitions. Convert from this to Component whenever a circuit is loaded. this allows graceful migration to upgraded Component definitions (which are added as new ComponentType cases). Old components can be converted to new on load.