### PR TITLE
Add a "not connected" component

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -210,7 +210,7 @@ module CommonTypes
     // deleted case into a case here which still exists.
     type ComponentType =
         // Legacy component: to be deleted
-        | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
+        | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel | NotConnected
         | BusCompare1 of BusWidth: int * CompareValue: uint32 * DialogTextValue: string
         | BusSelection of OutputWidth: int * OutputLSBit: int
         | Constant1 of Width: int * ConstValue: int64 * DialogTextValue: string
@@ -412,7 +412,7 @@ module CommonTypes
             // Legacy component: to be deleted
             //-----The cases here must be identical, and same order, as the main ComponentType (just copy the code!)----//
             // This allows unboxing to implement JSONComponent.Component <--> Component type conversion
-            | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel 
+            | Input1 of BusWidth: int * DefaultValue: int option | Output of BusWidth: int | Viewer of BusWidth: int | IOLabel | NotConnected
             | BusCompare1 of BusWidth: int * CompareValue: uint32 * DialogTextValue: string
             | BusSelection of OutputWidth: int * OutputLSBit: int
             | Constant1 of Width: int * ConstValue: int64 * DialogTextValue: string

--- a/src/Renderer/Common/WidthInferer.fs
+++ b/src/Renderer/Common/WidthInferer.fs
@@ -180,6 +180,9 @@ let private calculateOutputPortsWidth
                       else  
                         makeWidthInferErrorEqual width n [getConnectionIdForPort 0]
         | _ -> failwithf "what? Impossible case in calculateOutputPortsWidth for: %A" comp.Type
+    | NotConnected ->
+        assertInputsSize inputConnectionsWidth 1 comp
+        Ok Map.empty
     | IOLabel->
         match getWidthsForPorts inputConnectionsWidth ([InputPortNumber 0]) with
         | [None] -> Ok <| Map.empty

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -166,7 +166,7 @@ let getSymbolColour compType clocked (theme:ThemeType) =
             -> "lightblue"  //for clocked components
         |Input _ |Input1 (_,_) |Output _ |Viewer _ |Constant _ |Constant1 _ 
             -> "#E8D0A9"  //dark orange: for IO
-        | SplitWire _ | MergeWires _ | BusSelection _ | NbitSpreader _ | IOLabel ->
+        | SplitWire _ | MergeWires _ | BusSelection _ | NbitSpreader _ | IOLabel | NotConnected ->
             "rgb(120,120,120)"
         | _ -> "rgba(255,255,217,1)" //lightyellow: for combinational components
 
@@ -209,7 +209,7 @@ let calcLabelBoundingBox (sym: Symbol) =
 
     let margin = 
         match sym.Component.Type with
-        | IOLabel | BusSelection _ -> Constants.thinComponentLabelOffsetDistance
+        | IOLabel | BusSelection _ | NotConnected -> Constants.thinComponentLabelOffsetDistance
         | _ -> Constants.componentLabelOffsetDistance
     let labH = Constants.componentLabelHeight //height of label text
     //let labW = getMonospaceWidth textStyle.FontSize comp.Label
@@ -572,7 +572,8 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
     | ComponentType.Viewer a -> (  1 , 0, gS ,  gS) 
-    | ComponentType.IOLabel  ->(  1 , 1, gS/2. ,  gS) 
+    | ComponentType.IOLabel  -> (  1 , 1, gS/2. ,  gS) 
+    | ComponentType.NotConnected -> (  1, 0, gS , gS)
     | Decode4 ->( 2 , 4 , 8.*gS  , 3.*gS) 
     | Constant1 (a, b,_) | Constant(a, b) -> (  0 , 1, gS ,  2.*gS) 
     | MergeWires -> ( 2 , 1, 2.*gS ,  2.*gS) 

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -43,7 +43,7 @@ let generateIOLabel (model: Model) (compType: ComponentType) (name:string) : str
         listSymbols
         |> List.collect (fun sym ->
             match sym.Component.Type with
-            |IOLabel -> []
+            |IOLabel | NotConnected -> []
             |_ -> 
                 let baseName,no = extractIOPrefix sym.Component.Label []
                 if baseName = newCompBaseName then
@@ -93,14 +93,14 @@ let generateLabel (model: Model) (compType: ComponentType) : string =
     let listSymbols = List.map snd (Map.toList model.Symbols) 
     let prefix = getPrefix compType
     match compType with
-    | IOLabel | BusSelection _ -> prefix
+    | IOLabel | BusSelection _ | NotConnected -> prefix
     | _ -> prefix + (generateLabelNumber listSymbols compType)
 
 let generateCopiedLabel (model: Model) (oldSymbol:Symbol) (compType: ComponentType) : string =
     let listSymbols = List.map snd (Map.toList model.Symbols) 
     let prefix = getPrefix compType
     match compType with
-    | IOLabel -> oldSymbol.Component.Label
+    | IOLabel | NotConnected -> oldSymbol.Component.Label
     | BusSelection _ -> prefix
     |Input _ | Input1 (_,_) |Output _ |Viewer _ -> generateIOLabel model compType oldSymbol.Component.Label
     | _ -> prefix + (generateLabelNumber listSymbols compType)

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -276,6 +276,8 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                 [|{X=0.;Y=H/2.};{X=W;Y=H/2.}|]
             | Viewer _ ->
                 [|{X=W/5.;Y=0};{X=0;Y=H/2.};{X=W/5.;Y=H};{X=W;Y=H};{X=W;Y=0}|]
+            | NotConnected ->
+                [|{X=0.;Y=H/2.};{X=W/3.;Y=H/2.};{X=W/3.;Y=H-H/4.};{X=W/3.;Y=H/4.};{X=W/3.;Y=H/2.}|]
             | MergeWires -> 
                 [|{X=0;Y=H/6.};{X=W/2.;Y=H/6.};{X=W/2.;Y=H/2.};{X=W;Y=H/2.};{X=W/2.;Y=H/2.};{X=W/2.;Y=5.*H/6.};{X=0;Y=5.*H/6.};{X=W/2.;Y=5.*H/6.};{X=W/2.;Y=H/6.}|]
             | SplitWire _ -> 
@@ -401,6 +403,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
         | SplitWire _ | MergeWires -> outlineColor colour, "4.0"
         |NbitSpreader _ -> outlineColor colour, "4.0"
         | IOLabel -> outlineColor colour, "4.0"
+        | NotConnected -> outlineColor colour, "4.0"
         | BusSelection _ -> outlineColor colour, "4.0"
         | _ -> "black", "1.0"
     
@@ -420,7 +423,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
         let pos = box.TopLeft - symbol.Pos + {X=margin;Y=margin} + Constants.labelCorrection
         let text = addStyledText {style with DominantBaseline="hanging"} pos comp.Label
         match Constants.testShowLabelBoundingBoxes, colour with
-        | false, "lightgreen" ->
+        | false, "lightgreen" when comp.Label <> "" ->
             let x,y = pos.X - margin*0.8, pos.Y - margin*0.8
             let w,h = box.W - margin*0.4, box.H - margin * 0.4
             let polyStyle = {defaultPolygon with Fill = "lightgreen"; StrokeWidth = "0"}

--- a/src/Renderer/Simulator/Builder.fs
+++ b/src/Renderer/Simulator/Builder.fs
@@ -114,6 +114,7 @@ let private getDefaultState compType =
     | Input1 _
     | Output _
     | IOLabel
+    | NotConnected
     | BusSelection _
     | BusCompare _
     | BusCompare1 _

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -514,7 +514,8 @@ let checkComponentNamesAreOk ((comps, conns): CanvasState) =
         |> List.filter (function
             | { Type = MergeWires _ }
             | { Type = SplitWire _ }
-            | { Type = BusSelection _ } -> false
+            | { Type = BusSelection _ }
+            | { Type = NotConnected } -> false
             | _ -> true)
         |> List.collect (fun comp ->
             let label = comp.Label.ToUpper()
@@ -538,7 +539,8 @@ let checkComponentNamesAreOk ((comps, conns): CanvasState) =
             | { Type = IOLabel _ }
             | { Type = MergeWires _ }
             | { Type = SplitWire _ }
-            | { Type = BusSelection _ } -> false
+            | { Type = BusSelection _ }
+            | { Type = NotConnected } -> false
             | _ -> true)
         |> List.groupBy (fun comp -> comp.Label)
         |> List.filter (fun (_, compL) -> List.length compL > 1)

--- a/src/Renderer/Simulator/Fast/FastCreate.fs
+++ b/src/Renderer/Simulator/Fast/FastCreate.fs
@@ -75,6 +75,7 @@ let getPortNumbers (sc: SimulationComponent) =
         | NbitsNot _
         | NbitSpreader _
         | CounterNoLoad _ -> 1, 1
+        | NotConnected -> 1, 0
         | MergeWires
         | NbitsXor _
         | NbitsOr _
@@ -162,6 +163,7 @@ let findBigIntState (fc: FastComponent) =
     | Demux2
     | Demux4
     | Demux8 -> fc.OutputWidth 0 > 32, None
+    | NotConnected -> false, None
     // Components with variable width
     | MergeWires ->
         fc.InputWidth 0 > 32
@@ -431,6 +433,7 @@ let addComponentWaveDrivers (f: FastSimulation) (fc: FastComponent) (pType: Port
             | IOLabel, PortType.Input
             | Input1 _, PortType.Input
             | Viewer _, PortType.Input
+            | NotConnected, PortType.Input
             | Output _, PortType.Input -> false, false
             | Constant1 _, _ -> // special case because constant output drivers are needed!
                 true, false

--- a/src/Renderer/Simulator/Fast/FastReduce.fs
+++ b/src/Renderer/Simulator/Fast/FastReduce.fs
@@ -317,6 +317,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     | IOLabel,true ->
         let bits = insBigInt 0
         putBigInt 0 bits
+    | NotConnected, _ -> ()
     | Not, false ->
         let bit = insUInt32 0
         putUInt32 0 <| bitNot bit

--- a/src/Renderer/Simulator/Fast/FastReduce.fs
+++ b/src/Renderer/Simulator/Fast/FastReduce.fs
@@ -1425,6 +1425,7 @@ let fastReduceFData (maxArraySize: int) (numStep: int) (isClockedReduction: bool
         //let bits = comp.InputLinks[0][simStep]
         //printfn "Reducing IOLabel %A" comp.SimComponent.Label
         put 0 bits
+    | NotConnected -> ()
     | Not ->
         match (ins 0) with
         | Data _ ->

--- a/src/Renderer/Simulator/SynchronousUtils.fs
+++ b/src/Renderer/Simulator/SynchronousUtils.fs
@@ -29,6 +29,7 @@ let couldBeSynchronousComponent compType : bool =
     | Input1 _
     | Output _
     | IOLabel
+    | NotConnected
     | Constant1 _
     | BusSelection _
     | BusCompare _
@@ -98,6 +99,7 @@ let rec hasSynchronousComponents graph : bool =
         | Input1 _
         | Output _
         | IOLabel
+        | NotConnected
         | BusSelection _
         | BusCompare _
         | BusCompare1 _

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -408,6 +408,8 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
     | IOLabel _
     | Input1 _ -> sprintf $"assign %s{outs 0} = %s{ins 0};\n"
 
+    | NotConnected -> ""
+
     | Not -> sprintf "assign %s = ! %s;\n" (outs 0) (ins 0)
     | And
     | Or

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -812,7 +812,8 @@ let viewCatalogue model dispatch =
                           catTip1 "Wire Label" (fun _ -> createIOPopup false "label" (fun _ -> IOLabel) model dispatch) "Labels with the same name connect \
                                                                                                                          together wires within a sheet. Each set of labels \
                                                                                                                          muts have exactly one driving input. \
-                                                                                                                         A label can also be used to terminate an unused output"]
+                                                                                                                         A label can also be used to terminate an unused output"
+                          catTip1 "Not Connected" (fun _ -> createComponent (NotConnected) "" model dispatch) "Not connected component to terminate unused output."]                          
                     makeMenuGroup
                         "Buses"
                         [ catTip1 "MergeWires"  (fun _ -> createComponent MergeWires "" model dispatch) "Use Mergewires when you want to \

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -668,6 +668,7 @@ let private makeDescription (comp:Component) model dispatch =
     | Constant1 _ | Constant _ -> str "Constant Wire."
     | Output _ -> str "Output."
     | Viewer _ -> str "Viewer."
+    | NotConnected -> str "Not connected."
     | BusCompare _ | BusCompare1 _ -> str "The output is one if the bus unsigned binary value is equal to the integer specified. \
                                            This will display in hex on the design sheet. Busses of greater than 32 bits are not supported"
     | BusSelection _ -> div [] [
@@ -889,7 +890,7 @@ let viewSelectedComponent (model: ModelType.Model) dispatch =
         match model.Sheet.SelectedComponents with
         | [cid] ->
             match Map.tryFind cid symbols with
-            | Some {Component ={Type=MergeWires | SplitWire _ | BusSelection _}} -> true
+            | Some {Component ={Type=MergeWires | SplitWire _ | BusSelection _ | NotConnected}} -> true
             | _ -> false
         | _ -> false
 
@@ -949,7 +950,7 @@ let viewSelectedComponent (model: ModelType.Model) dispatch =
             makeExtraInfo model comp labelText  dispatch
             let required = 
                 match comp.Type with 
-                | SplitWire _ | MergeWires | BusSelection _ -> false | _ -> true
+                | SplitWire _ | MergeWires | BusSelection _ | NotConnected -> false | _ -> true
             let isBad = 
                 if model.PopupDialogData.BadLabel then 
                     match label' with 

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -349,6 +349,7 @@ let getCompDetails fs wave =
         | Constant1 _ -> "What? can't happen", true
         | Viewer _ -> "Viewer", true
         | IOLabel _-> "Wire Label", true
+        | NotConnected -> "What? can't happen", true
         | Not | And | Or | Xor | Nand | Nor | Xnor -> 
             let gateType = $"{fc.FType}".ToUpper()
             $"{gateType} gate", false
@@ -396,7 +397,7 @@ let getCompDetails fs wave =
 /// Which group (for selector classification) is a component in?
 let getCompGroup fs wave =
     match fs.WaveComps[wave.WaveId.Id].FType with
-    | Input1 _ | Output _ | Constant1 _ | Viewer _ | IOLabel _->
+    | Input1 _ | Output _ | Constant1 _ | Viewer _ | IOLabel _ | NotConnected ->
         InputOutput
     | Not | And | Or | Xor | Nand | Nor | Xnor ->
         Gates

--- a/src/Renderer/UI/WaveSim/WaveSimSelect.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimSelect.fs
@@ -41,7 +41,7 @@ let getInputPortName (compType: ComponentType) (port: InputPortNumber) : string 
         | InputPortNumber 0 -> ".SEL"
         | _ -> ".DATA"
 
-    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ |CounterNoEnableLoad _ ->
+    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ | CounterNoEnableLoad _ | NotConnected ->
         ""
     | DFF | Register _ ->
         ".D"
@@ -134,6 +134,7 @@ let getInputName (withComp: bool) (comp: FastComponent) (port: InputPortNumber) 
 
         | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
         | Input _ -> failwithf "Legacy Input component types should never occur"
+        | NotConnected -> failwithf "NotConnected should not occur in getInputName"
         | IOLabel -> failwithf "IOLabel should not occur in getInputName"
         | MergeWires -> failwithf "MergeWires should not occur in getInputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getInputName"
@@ -150,7 +151,7 @@ let getOutputPortName (compType: ComponentType) (port: OutputPortNumber) : strin
     match compType with
     | Not | And | Or | Xor | Nand | Nor | Xnor | Decode4 | Mux2 | Mux4 | Mux8 | BusCompare _ | BusCompare1 _ | NbitsXor _ | NbitsNot _  | NbitSpreader _ | NbitsAnd _ | NbitsOr _ |Shift _->
         ".OUT"
-    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ | IOLabel ->
+    | Input1 _ | Output _ | Constant1 _ | Constant _ | Viewer _ | IOLabel | NotConnected ->
         ""
     | Demux2 | Demux4 | Demux8 ->
         "." + string port
@@ -212,6 +213,7 @@ let getOutputName (withComp: bool) (comp: FastComponent) (port: OutputPortNumber
 
         | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
         | Input _ -> failwithf "Legacy Input component types should never occur"
+        | NotConnected -> failwithf "NotConnected should not occur in getOutputName"
         | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
         | BusSelection _ -> failwithf "BusSelection should not occur in getOutputName"
@@ -568,7 +570,7 @@ let rec makeSheetRow  (showDetails: bool) (ws: WaveSimModel) (dispatch: Msg -> U
 
 
 
-let  selectWaves (ws: WaveSimModel) (subSheet: string list) (dispatch: Msg -> unit) : ReactElement =
+let selectWaves (ws: WaveSimModel) (subSheet: string list) (dispatch: Msg -> unit) : ReactElement =
 
     if not ws.WaveModalActive then div [] []
     else


### PR DESCRIPTION
This new component replaces wire labels as endpoints for unconnected component outputs.