### PR TITLE
Refactor update function, popups, add context menus

### DIFF
--- a/src/Renderer/DrawBlock/SymbolPortHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolPortHelpers.fs
@@ -94,7 +94,7 @@ let inline showPorts (model: Model) compList =
             Map.add sId (showSymbolPorts resetSymbols[sId])
 
     let customHint =
-        match List.exists (fun cId -> Helpers.isCustom model.Symbols[cId].Component.Type) compList with
+        match List.exists (fun cId -> Map.containsKey cId model.Symbols && Helpers.isCustom model.Symbols[cId].Component.Type) compList with
         | true -> Some Constants.customComponentHint
         | false -> None
 

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -314,6 +314,8 @@ type TTMsg =
 type Msg =
     | ShowExitDialog
     | Sheet of DrawModelType.SheetT.Msg
+    | UpdateUISheetTrail of (string list -> string list)
+    | SheetBackAction of (Msg -> unit)
     | SynchroniseCanvas
     | JSDiagramMsg of JSDiagramMsg
     | KeyboardShortcutMsg of KeyboardShortcutMsg
@@ -497,6 +499,9 @@ type Model = {
     /// which top-level sheet is used by wavesim
     WaveSimSheet: string option
 
+    /// A breadcrumb-like trail of visited sheets used for UI back button
+    UISheetTrail: string list
+
     /// If the application has a modal spinner waiting for simulation
     Spinner: (Model -> Model) option
         
@@ -585,6 +590,7 @@ let currentTruthTable_ = Lens.create (fun a -> a.CurrentTruthTable) (fun s a -> 
 let popupDialogData_ = Lens.create (fun a -> a.PopupDialogData) (fun p a -> {a with PopupDialogData = p})
 let selectedComponent_ = Lens.create (fun a -> a.SelectedComponent) (fun s a -> {a with SelectedComponent = s})
 let userData_ = Lens.create (fun a -> a.UserData) (fun s a -> {a with UserData = s})
+let uISheetTrail_ = Lens.create (fun a -> a.UISheetTrail) (fun s a -> {a with UISheetTrail = s})
 
 
 let currentProj_ = Lens.create (fun a -> a.CurrentProj) (fun s a -> {a with CurrentProj = s})

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -362,7 +362,7 @@ type Msg =
     | UpdateProject of (Project -> Project)
     | UpdateModel of (Model -> Model)
     | UpdateProjectWithoutSyncing of (Project->Project)
-    | ShowPopup of ((Msg -> Unit) -> PopupDialogData -> ReactElement)
+    | ShowPopup of ((Msg -> Unit) -> Model -> ReactElement)
     | ShowStaticInfoPopup of (string * ReactElement * (Msg -> Unit))
     | ClosePopup
     | SetPopupDialogText of string option
@@ -543,7 +543,7 @@ type Model = {
     /// the project contains, as loadable components, the state of each of its sheets
     CurrentProj : Project option
     /// function to create popup pane if present
-    PopupViewFunc : ((Msg -> Unit) -> PopupDialogData -> Fable.React.ReactElement) option
+    PopupViewFunc : ((Msg -> Unit) -> Model -> Fable.React.ReactElement) option
     /// function to create spinner popup pane if present (overrides otehr popups)
     SpinnerPayload : SpinPayload option
     /// data to populate popup (may not all be used)

--- a/src/Renderer/Playground.fs
+++ b/src/Renderer/Playground.fs
@@ -49,7 +49,8 @@ module TestFonts =
         let textToTestDefault = "iiiimmmmyyyy0123456789"
         fontStyleDefault |> Some |> SetPopupConstraintErrorMsg |> TruthTableMsg |> dispatch
         textToTestDefault |> Some |> SetPopupDialogText  |> dispatch
-        fun (dialogData : PopupDialogData) ->
+        fun (model: Model) ->
+            let dialogData = model.PopupDialogData
             let fontFamily =
                 match dialogData.ConstraintErrorMsg with
                 | None -> fontStyleDefault
@@ -106,7 +107,7 @@ module TestFonts =
                 body
             "Change Font"
             (fun dd ->
-                Option.defaultValue "" dd.ConstraintErrorMsg
+                Option.defaultValue "" dd.PopupDialogData.ConstraintErrorMsg
                 |> nextFontFamily
                 |> Some
                 |> SetPopupConstraintErrorMsg

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -115,7 +115,8 @@ let private createInputPopup typeStr (compType: int * int option -> ComponentTyp
         dialogPopupBodyTextAndTwoInts 1 (beforeText, placeholder) (beforeInt, beforeDefaultValue) (intDefault, 0) dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model: Model) ->
+            let dialogData = model.PopupDialogData
             // TODO: format text for only uppercase and allowed chars (-, not number start)
             // TODO: repeat this throughout this file and selectedcomponentview (use functions)
             let inputText = getText dialogData
@@ -124,7 +125,8 @@ let private createInputPopup typeStr (compType: int * int option -> ComponentTyp
             createComponent (compType (widthInt, Some defaultValueInt)) (FileMenuHelpers.formatLabelFromType (compType (widthInt, Some defaultValueInt)) inputText) model dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let notGoodLabel =
                 getText dialogData
                 |> (fun s -> s = "" || not (String.startsWithLetter s))
@@ -145,7 +147,8 @@ let private createIOPopup hasInt typeStr compType (model:Model) dispatch =
         | false -> dialogPopupBodyOnlyText beforeText placeholder dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             // TODO: format text for only uppercase and allowed chars (-, not number start)
             // TODO: repeat this throughout this file and selectedcomponentview (use functions)
             let inputText = getText dialogData
@@ -153,7 +156,8 @@ let private createIOPopup hasInt typeStr compType (model:Model) dispatch =
             createComponent (compType inputInt) (FileMenuHelpers.formatLabelFromType (compType inputInt) inputText) model dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let notGoodLabel =
                 getText dialogData
                 |> (fun s -> s = "" || not (String.startsWithLetter s))
@@ -168,7 +172,8 @@ let createSheetDescriptionPopup (model:Model) previousDescr sheetName dispatch =
     let body =  dialogPopupBodyOnlyTextWithDefaultValue beforeText "Description" previousDescr dispatch
     let buttonText = "Save"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let descr = getText dialogData
             let descrToSave =
                 match descr with
@@ -206,7 +211,7 @@ let createSheetDescriptionPopup (model:Model) previousDescr sheetName dispatch =
                 saveOpenFileActionWithModelUpdate model' dispatch |> ignore
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) ->
+        fun (model: Model) ->
             false  //allow all
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
@@ -218,13 +223,14 @@ let private createNbitsAdderPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating adder %d" inputInt
             createCompStdLabel (NbitsAdder inputInt) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 
@@ -236,13 +242,14 @@ let private createNbitsXorPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating XOR %d" inputInt
             createCompStdLabel (NbitsXor(inputInt,None)) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model: Model) -> getInt model.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 let private createNbitsAndPopup (model:Model) dispatch =
@@ -253,13 +260,14 @@ let private createNbitsAndPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating XOR %d" inputInt
             createCompStdLabel (NbitsAnd inputInt) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model'.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 let private createNbitsOrPopup (model:Model) dispatch =
@@ -270,13 +278,14 @@ let private createNbitsOrPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating XOR %d" inputInt
             createCompStdLabel (NbitsOr inputInt) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model'.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 let private createNbitsNotPopup (model:Model) dispatch =
@@ -287,13 +296,14 @@ let private createNbitsNotPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating XOR %d" inputInt
             createCompStdLabel (NbitsNot inputInt) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model'.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 let private createNbitSpreaderPopup (model:Model) dispatch =
@@ -304,13 +314,14 @@ let private createNbitSpreaderPopup (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             //printfn "creating XOR %d" inputInt
             createCompStdLabel (NbitSpreader inputInt) {model with LastUsedDialogWidth = inputInt} dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 
@@ -323,12 +334,13 @@ let private createSplitWirePopup model dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             createCompStdLabel (SplitWire inputInt) model dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model'.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 /// two react text lines in red
@@ -401,7 +413,8 @@ let private createConstantPopup model dispatch =
     let beforeInt =
         fun _ -> str "How many bits has the wire carrying the constant?"
     let intDefault = 1
-    let parseConstantDialog dialog =
+    let parseConstantDialog model' =
+        let dialog = model'.PopupDialogData
         parseConstant 64
             (Option.defaultValue intDefault dialog.Int)
             (Option.defaultValue "" dialog.Text)
@@ -410,7 +423,8 @@ let private createConstantPopup model dispatch =
     let body = dialogPopupBodyIntAndText beforeText placeholder beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model: Model) ->
+            let dialogData = model.PopupDialogData
             let width = getInt dialogData
             let text = Option.defaultValue "" dialogData.Text
             let constant = 
@@ -434,13 +448,14 @@ let private createBusSelectPopup model dispatch =
     let body = dialogPopupBodyTwoInts (beforeInt,beforeInt2) (intDefault, int64 intDefault2) "60px" dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let width = getInt dialogData
             let lsb = int32 (getInt2 dialogData)
             createCompStdLabel (BusSelection(width,lsb)) model dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1 || getInt2 dialogData < 0L
+        fun (model': Model) -> getInt model'.PopupDialogData < 1 || getInt2 model'.PopupDialogData < 0L
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 let private createBusComparePopup (model:Model) dispatch =
@@ -448,14 +463,16 @@ let private createBusComparePopup (model:Model) dispatch =
     let beforeInt =
         fun _ -> str "How many bits width is the input bus?"
     let intDefault = 1
-    let parseBusCompDialog dialog =
+    let parseBusCompDialog model' =
+        let dialog = model'.PopupDialogData
         parseBusCompareValue 32 (Option.defaultValue intDefault dialog.Int) (Option.defaultValue "" dialog.Text)
     let beforeText = (fun d -> div [] [d |> parseBusCompDialog |> fst; br [] ])
     let placeholder = "Value: decimal, 0x... hex, 0b... binary"   
     let body = dialogPopupBodyIntAndText beforeText placeholder beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let width = getInt dialogData
             let text = Option.defaultValue "" dialogData.Text
             let constant = 
@@ -485,12 +502,13 @@ let private createRegisterPopup regType (model:Model) dispatch =
     let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let inputInt = getInt dialogData
             createCompStdLabel (regType inputInt) model dispatch
             dispatch ClosePopup
     let isDisabled =
-        fun (dialogData : PopupDialogData) -> getInt dialogData < 1
+        fun (model': Model) -> getInt model'.PopupDialogData < 1
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 
@@ -508,7 +526,8 @@ let private createMemoryPopup memType model (dispatch: Msg -> Unit) =
     let body = dialogPopupBodyMemorySetup intDefault dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let addressWidth, wordWidth, source, msgOpt = getMemorySetup dialogData intDefault
             let initMem = {
                 AddressWidth = addressWidth
@@ -525,7 +544,8 @@ let private createMemoryPopup memType model (dispatch: Msg -> Unit) =
             | Error mess ->
                 dispatch <| SetPopupDialogMemorySetup (addError (Some mess) dialogData.MemorySetup)
     let isDisabled =
-        fun (dialogData : PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             let addressWidth, wordWidth, source,_ = getMemorySetup dialogData 1
             let error = 
                 match dialogData.MemorySetup with 

--- a/src/Renderer/UI/ContextMenus.fs
+++ b/src/Renderer/UI/ContextMenus.fs
@@ -20,6 +20,7 @@ open ElectronAPI
 /// menu and item names can be arbitrary strings
 /// add menus as here
 let contextMenus = [
+        "CustomComponent", ["Go to sheet"]
         "Menu1", ["Item1"; "Item with spaces"] // example menu
         "MenuB", ["Averylongitemwill still work"; "tiny"; "medium"] // example menu
         "", [] // Empty string for no context menu.
@@ -62,13 +63,14 @@ let makeMenu
                 cases
             |> List.toArray
     fun ev ->
-        let template =
-            cases
-            |> Array.map (fun s -> makeClickableReturner dispatchToRenderer ev (menuType, s))
-            |> Array.map U2.Case1
-        let (menu:Menu) = mainProcess.Menu.buildFromTemplate template
-        let popupOptions = Some {| window = window |}
-        menu.popup (unbox popupOptions)|> ignore
+        if menuType <> "" then
+            let template =
+                cases
+                |> Array.map (fun s -> makeClickableReturner dispatchToRenderer ev (menuType, s))
+                |> Array.map U2.Case1
+            let (menu:Menu) = mainProcess.Menu.buildFromTemplate template
+            let popupOptions = Some {| window = window |}
+            menu.popup (unbox popupOptions)|> ignore
 
 
     

--- a/src/Renderer/UI/FileMenuHelpers.fs
+++ b/src/Renderer/UI/FileMenuHelpers.fs
@@ -111,7 +111,8 @@ let makeSourceMenu
         (updateMem: ComponentId -> (Memory1 -> Memory1) -> Unit)
         (cid: ComponentId)
         (dispatch: Msg -> Unit)
-        (dialog: PopupDialogData) =
+        (modelCurrent: Model) =
+    let dialog = modelCurrent.PopupDialogData
     let projOpt = model.CurrentProj
     match dialog.MemorySetup with
     | None ->

--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -1255,6 +1255,19 @@ let viewTopMenu model dispatch =
                                   
                                 ]
                             ]
+                      Navbar.Item.div []
+                          (if model.UISheetTrail = [] then
+                                []
+                          else
+                                [ Navbar.Item.div []
+                                    [ Button.button 
+                                        [   Button.OnClick(fun _ -> dispatch <| SheetBackAction dispatch) 
+                                            Button.Color IsSuccess
+                                        ] 
+                                        [ str "Back" ] 
+                                  
+                                    ]
+                                ])
                       Navbar.End.div []
                         [ Navbar.Item.div []
                                 [

--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -611,15 +611,16 @@ let renameFileInProject name project model dispatch =
         let buttonText = "Rename"
 
         let buttonAction =
-            fun (dialogData: PopupDialogData) ->
+            fun (model: Model) ->
                 // Create empty file.
-                let newName = (getText dialogData).ToLower()
+                let newName = (getText model.PopupDialogData).ToLower()
                 // rename the file in the project.
                 dispatch(ExecFuncInMessage(renameSheet name newName, dispatch))
                 dispatch ClosePopup
 
         let isDisabled =
-            fun (dialogData: PopupDialogData) ->
+            fun (model: Model) ->
+                let dialogData = model.PopupDialogData
                 let dialogText = getText dialogData
                 (isFileInProject dialogText project) || (dialogText = "")
 
@@ -714,7 +715,8 @@ let addFileToProject model dispatch =
         let body = dialogPopupBodyOnlyText before placeholder dispatch
         let buttonText = "Add"
         let buttonAction =
-            fun (dialogData: PopupDialogData) ->
+            fun (model': Model) ->
+                    let dialogData = model'.PopupDialogData
                     // Create empty file.
                     let name = (getText dialogData).ToLower()
                     createEmptyDgmFile project.ProjectPath name
@@ -744,7 +746,8 @@ let addFileToProject model dispatch =
                     dispatch FinishUICmd
 
         let isDisabled =
-            fun (dialogData: PopupDialogData) ->
+            fun (model': Model) ->
+                let dialogData = model'.PopupDialogData
                 let dialogText = getText dialogData
                 (isFileInProject dialogText project) || (dialogText = "") || (maybeWarning dialogText project <> None)
 

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -52,6 +52,7 @@ let viewOnDiagramButtons model dispatch =
 let init() = {
     SpinnerPayload = None
     Spinner = None
+    UISheetTrail = []
     UserData = {
         WireType = BusWireT.Radial
         ArrowDisplay = true

--- a/src/Renderer/UI/SimulationView.fs
+++ b/src/Renderer/UI/SimulationView.fs
@@ -606,7 +606,8 @@ let viewSimulationError
         error
     ]
 
-let private simulationClockChangePopup (simData: SimulationData) (dispatch: Msg -> Unit) (dialog:PopupDialogData) =
+let private simulationClockChangePopup (simData: SimulationData) (dispatch: Msg -> Unit) (model':Model) =
+    let dialog = model'.PopupDialogData
     let step = simData.ClockTickNumber
     div [] 
         [
@@ -674,7 +675,8 @@ let simulateWithProgressBar (simProg: SimulationProgress) (model:Model) =
     
     
 
-let simulationClockChangeAction dispatch simData (dialog:PopupDialogData) =
+let simulationClockChangeAction dispatch simData (model': Model) =
+    let dialog = model'.PopupDialogData
     let clock = 
         match dialog.Int with
         | None -> failwithf "What - must have some number from dialog"
@@ -747,7 +749,8 @@ let private viewSimulationData (step: int) (simData : SimulationData) model disp
                 Button.button [
                     Button.Color IsSuccess
                     Button.OnClick (fun _ ->
-                        let isDisabled (dialogData:PopupDialogData) =
+                        let isDisabled (model': Model) =
+                            let dialogData = model'.PopupDialogData
                             match dialogData.Int with
                             | Some n -> n <= step
                             | None -> true

--- a/src/Renderer/UI/TruthTable/ConstraintReduceView.fs
+++ b/src/Renderer/UI/TruthTable/ConstraintReduceView.fs
@@ -188,7 +188,8 @@ let validateNumericalConstraint (con: Constraint) (allConstraints: ConstraintSet
 let dialogPopupNumericalConBody (cellIOs: CellIO list) existingCons infoMsg dispatch =
     let ttDispatch (ttMsg: TTMsg) : Unit = dispatch (TruthTableMsg ttMsg)
 
-    fun (dialogData: PopupDialogData) ->
+    fun (model': Model) ->
+        let dialogData = model'.PopupDialogData
         // Text to be displayed at the top of the body
         let preamble = str infoMsg
         // Which IO in the menu is currently selected
@@ -406,14 +407,16 @@ let createInputConstraintPopup (model: Model) (dispatch: Msg -> Unit) =
     let body = dialogPopupNumericalConBody inputs model.TTConfig.InputConstraints infoMsg dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.NewConstraint with
             | None -> ()
             | Some con ->
                 con |> AddInputConstraint |> ttDispatch
                 dispatch ClosePopup
     let isDisabled =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.ConstraintErrorMsg, dialogData.NewConstraint with
             | None, Some _ -> false
             | _, _ -> true
@@ -445,14 +448,16 @@ let createOutputConstraintPopup (model: Model) (dispatch: Msg -> Unit) =
     let body = dialogPopupNumericalConBody outputs model.TTConfig.OutputConstraints infoMsg dispatch
     let buttonText = "Add"
     let buttonAction =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.NewConstraint with
             | None -> ()
             | Some con ->
                 con |> AddOutputConstraint |> ttDispatch
                 dispatch ClosePopup
     let isDisabled =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.ConstraintErrorMsg, dialogData.NewConstraint with
             | None, Some _ -> false
             | _, _ -> true
@@ -640,7 +645,8 @@ let validateAlgebraInput (io: SimulationIO) (fsi: FSInterface) (tableSD: Simulat
     | AlgebraNotImplemented err -> Error err
 
 let dialogPopupReductionBody inputs tableSD (dispatch: Msg -> unit) =
-    fun (dialogData: PopupDialogData) ->
+    fun (model': Model) ->
+        let dialogData = model'.PopupDialogData
         let explanation = 
             str <|
             "Reduce the Truth Table down into something more compact and informative by setting
@@ -703,14 +709,16 @@ let createAlgReductionPopup model dispatch =
     let body = dialogPopupReductionBody inputs tableSD dispatch
     let buttonText = "Apply"
     let buttonAction =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.AlgebraInputs with
             | None -> failwithf "what? what? PopupDialogData.AlgebraInputs is None in popup body"
             | Some l -> 
                 ttDispatch <| SetTTAlgebraInputs l
                 dispatch ClosePopup
     let isDisabled =
-        fun (dialogData: PopupDialogData) ->
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
             match dialogData.AlgebraInputs, dialogData.AlgebraError with
             | _, Some _ | None, _ | Some [], _ -> true
             | Some lst, None -> false

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -122,6 +122,15 @@ let update (msg : Msg) oldModel =
         {model with WaveSimViewerWidth = w}
         |> withCmdNone
 
+    | SheetBackAction dispatch ->
+        processSheetBackAction dispatch model
+        |> withCmdNone        
+
+    | UpdateUISheetTrail updateFun ->
+        model
+        |> map uISheetTrail_ (updateFun >> List.filter (filterByOKSheets model))
+        |> withCmdNone
+
     | ReloadSelectedComponent width ->
         {model with LastUsedDialogWidth=width}
         |> withCmdNone
@@ -518,6 +527,7 @@ let update (msg : Msg) oldModel =
 
     | ContextMenuItemClick(menuType, item, dispatch) ->
         processContextMenuClick menuType item dispatch model
+        |> withCmdNone
 
     | DiagramMouseEvent ->
         model, Cmd.none // this now does nothing and should be removed

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -209,7 +209,7 @@ let update (msg : Msg) oldModel =
 
     | GenerateCurrentWaveforms ->
         // Update the wave simulator with new waveforms based on current WsModel
-        let ws = WaveSimHelpers.getWSModel model
+        let ws = getWSModel model
         WaveSim.refreshWaveSim false ws model
 
     | SetWaveComponentSelectionOpen (fIdL, show) ->       
@@ -229,76 +229,7 @@ let update (msg : Msg) oldModel =
         |> withCmdNone    
 
     | TryStartSimulationAfterErrorFix simType ->
-        let conns = BusWire.extractConnections model.Sheet.Wire
-        let comps = SymbolUpdate.extractComponents model.Sheet.Wire.Symbol
-        let canvasState = comps,conns
-        let simErrFeedback simErr otherMsg =
-                (SimulationView.getSimErrFeedbackMessages simErr model) @ [otherMsg]
-
-        match simType with
-            | StepSim ->
-                SimulationView.tryGetSimData canvasState model
-                |> function
-                    | Ok (simData) -> 
-                        model
-                        |> set currentStepSimulationStep_ (simData |> Ok |> Some)
-                        |> withMsg (StartSimulation (Ok simData))
-                    | Error simError ->
-                        model
-                        |> set currentStepSimulationStep_ (simError |> Error |> Some)
-                        |> withMsgs (simErrFeedback simError (StartSimulation (Error simError)))
-
-            | TruthTable ->
-                SimulationView.simulateModel None 2 canvasState model
-                |> function
-                    | Ok (simData), state ->
-                        if simData.IsSynchronous = false then
-                            model
-                            |> set currentStepSimulationStep_ (simData |> Ok |> Some)
-                            |> withCmdTTMsg (GenerateTruthTable (Some (Ok simData, state)))
-                        else
-                            { model with CurrentStepSimulationStep = None }
-                            |> withCmdTTMsg CloseTruthTable
-                    | Error simError, state ->
-                        let feedbackMsg = GenerateTruthTable (Some (Error simError, state)) |> TruthTableMsg
-                        model
-                        |> set currentStepSimulationStep_ (simError |> Error |> Some)
-                        |> withMsgs (simErrFeedback simError feedbackMsg)
-
-            | WaveSim ->
-                let model = MemoryEditorView.updateAllMemoryComps model
-                let wsSheet = 
-                    match model.WaveSimSheet with
-                    | None -> Option.get (getCurrFile model)
-                    | Some sheet -> sheet
-                let model = 
-                    model
-                    |> removeAllSimulationsFromModel
-                    |> fun model -> {model with WaveSimSheet = Some wsSheet}
-                let wsModel = WaveSimHelpers.getWSModel model
-                //printfn $"simSheet={wsSheet}, wsModel sheet = {wsModel.TopSheet},{wsModel.FastSim.SimulatedTopSheet}, state={wsModel.State}"
-                match SimulationView.simulateModel
-                        model.WaveSimSheet
-                        (WaveSimHelpers.Constants.maxLastClk + WaveSimHelpers.Constants.maxStepsOverflow)
-                        canvasState
-                        model with
-                //| None ->
-                //    dispatch <| SetWSModel { wsModel with State = NoProject; FastSim = FastCreate.emptyFastSimulation "" }
-                | (Error simError, _) ->
-                    model
-                    |> set currentStepSimulationStep_ (simError |> Error |> Some)
-                    |> withMsgs (simErrFeedback simError (SetWSModelAndSheet ({ wsModel with State = SimError simError }, wsSheet)))
-                | (Ok simData, canvState) ->
-                    if simData.IsSynchronous then
-                        SimulationView.setFastSimInputsToDefault simData.FastSim
-                        let wsModel = { wsModel with State = Loading ; FastSim = simData.FastSim }
-                        model
-                        |> set currentStepSimulationStep_ (simData |> Ok |> Some)
-                        |> withMsgs [SetWSModelAndSheet (wsModel, wsSheet) ; RefreshWaveSim wsModel]
-                    else
-                        model
-                        |> set currentStepSimulationStep_ (simData |> Ok |> Some)
-                        |> withMsg (SetWSModelAndSheet ({ wsModel with State = NonSequential }, wsSheet))
+        SimulationView.tryStartSimulationAfterErrorFix simType model
 
     | SetSimulationGraph (graph, fastSim) ->
         let simData =

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -1,32 +1,25 @@
 ﻿module UpdateHelpers
 
 open Elmish
-
 open Fulma
 open Fable.React
 open Fable.React.Props
 open ElectronAPI
 open FilesIO
 open SimulatorTypes
-open TruthTableTypes
-open TruthTableCreate
-open TruthTableReduce
 open ModelType
 open ModelHelpers
 open CommonTypes
 open Extractor
-open CatalogueView
 open FileMenuView
 open Sheet.SheetInterface
+open BusWireUpdateHelpers
 open DrawModelType
 open Fable.SimpleJson
-open Helpers
 open NumberHelpers
 open DiagramStyle
-open Fable.Core.JsInterop
 open Browser
 open PopupHelpers
-open Optics.Operators
 open Optics.Optic
 
 module Constants =
@@ -61,7 +54,9 @@ let shortDWSM (ws: WaveSimModel) =
 /// displayed using printf "%A".
 let shortDisplayMsg (msg:Msg) =
     match msg with
-    | ShowExitDialog -> None
+    | SheetBackAction _ -> Some "SheetBackAction"
+    | UpdateUISheetTrail _
+    | ShowExitDialog
     | SynchroniseCanvas -> None
     | Sheet sheetMsg -> shortDSheetMsg sheetMsg
     | JSDiagramMsg (InitCanvas _ )-> Some "JSDiagramMsg.InitCanvas"
@@ -255,29 +250,71 @@ let updateAllMemoryCompsIfNeeded (model:Model) =
 
 *)
 
+type RightClickElement =
+    | DBCustomComp of SymbolT.Symbol * CustomComponentType
+    | DBComp of SymbolT.Symbol
+    | DBWire of Wire: BusWireT.Wire * ASeg: BusWireT.ASegment list
+    | DBCanvas of XYPos
+    | DBInputPort of string
+    | DBOutputPort of string
+    | IssieElement of string
+    | NoMenu
+    
+
+let mutable rightClickElement: RightClickElement = NoMenu
+
 /// Function that works out from the right-click event and model
 /// what the current context menu should be.
 /// output should be a menu name as defined in ContextMenus.contextMenus, or "" for no menu.
 let getContextMenu (e: Browser.Types.MouseEvent) (model: Model) : string =
     //--------- the sample code below shows how useful info can be extracted from e --------------//
     // calculate equivalent sheet XY coordinates - valid if mouse is over schematic.
+    let symbols = model.Sheet.Wire.Symbol.Symbols
+    let bwModel = model.Sheet.Wire
     let sheetXYPos = SheetDisplay.getDrawBlockPos e DiagramStyle.getHeaderHeight model.Sheet
     let element:Types.Element = unbox e.target
     let htmlId = try element.id with | e -> "invalid"
     let drawOn = Sheet.mouseOn model.Sheet sheetXYPos
-    let clickType =
+    rightClickElement <- // mutable so that we have this info also in the callback from main
         match drawOn, htmlId with
         | SheetT.MouseOn.Canvas, "DrawBlockSVGTop" ->
-            printfn "Draw block sheet canvas"
-            "canvas"
+            printfn "Draw block sheet 'canvas'"
+            DBCanvas sheetXYPos
         | SheetT.MouseOn.Canvas, x ->
             printfn "Other issie element"
-            element.ToString()
-        | drawOn, _ ->
-            printfn "Draw block element: %A" drawOn
-            drawOn.ToString()
-    printfn "--------"
-    "Menu1" // send a string so contextMenu.fs code can bring up the correct menu
+            IssieElement (element.ToString())
+        | SheetT.MouseOn.Component compId, _ ->
+            match Map.tryFind compId symbols with
+            | None ->
+                NoMenu
+            | Some {Component = {Type = Custom ct}} ->
+                DBCustomComp (symbols[compId], ct)
+            | Some sym ->
+                DBComp sym
+        | SheetT.MouseOn.Connection connId, _ ->
+            Map.tryFind connId bwModel.Wires
+            |> function | None -> NoMenu
+                        | Some wire ->
+                            let segs = getClickedSegment  bwModel connId sheetXYPos
+                            match segs with
+                            | [] -> NoMenu
+                            | segs ->DBWire(wire, segs)
+        | SheetT.MouseOn.InputPort (InputPortId s, _),_ -> DBInputPort s
+        | SheetT.MouseOn.OutputPort (OutputPortId s, _),_ -> DBOutputPort s
+        | _ -> NoMenu
+            
+    // return the desired menu
+    match rightClickElement with
+    | DBCustomComp _->        
+        "CustomComponent"
+    | DBCanvas x ->
+        printfn "Other issie element %s" (element.ToString())
+        "" // no menu yet
+    | _ ->
+        printfn $"Clicked on '{drawOn.ToString()}'"
+        "" // default is no menu
+            
+
 
 /// Function that implement action based on context menu item click.
 /// menuType is the menu from chooseContextMenu.
@@ -285,15 +322,39 @@ let getContextMenu (e: Browser.Types.MouseEvent) (model: Model) : string =
 let processContextMenuClick
         (menuType: string) // name of menu
         (item: string) // name of menu item clicked
-        (dispatch: Msg -> unit) // disapatch function
+        (dispatch: Msg -> unit) // dispatch function
         (model: Model)
-            : Model * Cmd<Msg> = // can change state directly (Model) or via a message wrapped in Cmd.ofMsg.
-    match menuType,item with
+            : Model = // can change state directly (Model) or via a message wrapped in Cmd.ofMsg.
+    match rightClickElement,item with
+    | DBCustomComp(sym,ct), "Go to sheet" ->
+        let p = Option.get model.CurrentProj
+        openFileInProject ct.Name p model dispatch
+        model
+        |> map uISheetTrail_ (fun trail -> p.OpenFileName :: trail)
     | _ ->
-        printfn "%s" $"Context menu item not implemented: {menuType} -> {item}"
-    model, Cmd.none
+        printfn "%s" $"Context menu item not implemented: {rightClickElement} -> {item}"
+        model
 
+let filterByOKSheets (model: Model) (sheet: string) =
+    match model.CurrentProj with
+    | Some p when p.OpenFileName = sheet -> false
+    | Some p when p.LoadedComponents |> List.forall (fun ldc -> ldc.Name <> sheet) -> false
+    | _ -> true   
 
+let processSheetBackAction (dispatch: Msg -> unit) (model: Model)  =
+    let goodSheets =
+        model.UISheetTrail
+        |> List.filter (filterByOKSheets model) // make sure trail still exists!
+    let trail =
+        match goodSheets with
+        | [] ->
+            []
+        | (sheet :: others) ->
+            let p = Option.get model.CurrentProj
+            FileMenuView.openFileInProject sheet p model dispatch
+            others
+    model
+    |> set uISheetTrail_ trail
 
 //-------------------------------------------------------------------------------------------------//
 //-------------------------------------UPDATE FUNCTIONS--------------------------------------------//
@@ -505,8 +566,10 @@ let exitApp (model:Model) =
     writeUserData model
     renderer.ipcRenderer.send("exit-the-app",[||])
 
-///Tests physical equality on two objects
-///Used because Msg type does not support structural equality
+/// Tests physical equality on two objects.
+/// Used because Msg type does not support structural equality.
+/// **DANGER** will only work for messages which are physically the the same.
+/// In this use case that is fine.
 let isSameMsg = LanguagePrimitives.PhysicalEquality 
 
 
@@ -538,5 +601,5 @@ let executePendingMessagesF n model =
     else 
         model, Cmd.none
 
-    
+
     

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -232,7 +232,7 @@ let mutable lastMemoryUpdateCheck = 0.
 
 let updateAllMemoryCompsIfNeeded (model:Model) =
     let time = TimeHelpers.getTimeMs()
-    if time - lastMemoryUpdateCheck > Constants.memoryUpdateCheckTime && (WaveSimHelpers.getWSModel model).State = Success then
+    if time - lastMemoryUpdateCheck > Constants.memoryUpdateCheckTime && (getWSModel model).State = Success then
         printfn "checking update of memories"
         lastMemoryUpdateCheck <- time
         MemoryEditorView.updateAllMemoryComps model

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -989,7 +989,7 @@ let refreshButtonAction canvasState model dispatch = fun _ ->
         |> fun model -> {model with WaveSimSheet = Some wsSheet}
     let wsModel = getWSModel model
     //printfn $"simSheet={wsSheet}, wsModel sheet = {wsModel.TopSheet},{wsModel.FastSim.SimulatedTopSheet}, state={wsModel.State}"
-    match SimulationView.simulateModel model.WaveSimSheet (WaveSimHelpers.Constants.maxLastClk + WaveSimHelpers.Constants.maxStepsOverflow)  canvasState model with
+    match SimulationView.simulateModel model.WaveSimSheet (ModelHelpers.Constants.maxLastClk + ModelHelpers.Constants.maxStepsOverflow)  canvasState model with
     //| None ->
     //    dispatch <| SetWSModel { wsModel with State = NoProject; FastSim = FastCreate.emptyFastSimulation "" }
     | (Error e, _) ->

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -17,6 +17,7 @@ open NumberHelpers
 
 
 module Constants =
+
     /// initial time running simulation without spinner to check speed (in ms)
     let initSimulationTime = 100.
     /// max estimated time to run simulation and not need a spinner (in ms)
@@ -38,11 +39,6 @@ module Constants =
     let yTop = spacing
     /// y-coordiante of the bottom of a waveform
     let yBot = waveHeight + spacing
-
-    /// TODO: Remove this limit, after making simulation interruptable This stops the waveform simulator moving past 1000 clock cycles.
-    let maxLastClk = 1000
-    /// Needed to prevent possible overrun of simulation arrays
-    let maxStepsOverflow = 3
 
     /// minium number of cycles on screen when zooming in
     let minVisibleCycles = 3
@@ -122,26 +118,6 @@ let xShift clkCycleWidth =
     if highZoom clkCycleWidth then
         clkCycleWidth / 2.
     else Constants.nonBinaryTransLen
-
-/// Get the current WaveSimModel used by the Model (index the map using the current wavesim sheet).
-/// If no WaveSimModel for that sheet, return an empty wave sim model.
-let rec getWSModel model : WaveSimModel =
-    match model.WaveSimSheet with
-    | Some sheet ->
-        Map.tryFind sheet model.WaveSim
-        |> function
-            | Some wsModel ->
-                // printf "Sheet %A found in model" model.WaveSimSheet
-                wsModel
-            | None ->
-                // printf "Sheet %A not found in model" model.WaveSimSheet
-                initWSModel
-    | None ->
-        match getCurrFile model with
-        | None -> 
-            initWSModel
-        | Some sheet ->
-            getWSModel {model with WaveSimSheet = Some sheet}
         
 
 /// Width of one clock cycle.

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -1,6 +1,7 @@
 module WaveSimStyle
 
 open ModelType
+open ModelHelpers
 open WaveSimHelpers
 
 open Fulma


### PR DESCRIPTION
Quite a large cleanup and refactoring.

All code using popups must now use `Model -> (Msg -> unit) -> ReactElement` popup type instead of previous `PopupDialogData -> (Msg- > unit) -> ReactElement.

the change is trivial and old code changes are guided by the compiler.