### PR TITLE
Import sheet feature v1

### DIFF
--- a/src/Renderer/DrawBlock/PopupHelpers.fs
+++ b/src/Renderer/DrawBlock/PopupHelpers.fs
@@ -141,6 +141,9 @@ let preventDefault (e: Browser.Types.ClipboardEvent) = e.preventDefault()
 let getText (dialogData : PopupDialogData) =
     Option.defaultValue "" dialogData.Text
 
+let getImportDecisions (dialogData : PopupDialogData) =
+    dialogData.ImportDecisions
+
 let getCode (dialogData : PopupDialogData) =
     Option.defaultValue "" dialogData.VerilogCode
 

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -280,37 +280,20 @@ let getBaseNameNoExtension filePath =
             )
         firstSplit + rest
 
-let private projectFileFilters =
+let private makeFileFilters (name : string) (extn : string) =
     createObj !![
-        "name" ==> "ISSIE project file"
-        "extensions" ==> ResizeArray [ "dprj" ]
+    "name" ==> name
+    "extensions" ==> ResizeArray [ extn ]
     ] 
     |> unbox<FileFilter> 
     |> Array.singleton
-
-let private ramFileFilters =
-    createObj !![
-        "name" ==> "Memory contents File"
-        "extensions" ==> ResizeArray [ "ram" ]
-    ] 
-    |> unbox<FileFilter> 
-    |> Array.singleton
-
-let private projectFilters =
-    createObj !![ 
-        "name" ==> "ISSIE project"   
-        "extensions" ==> ResizeArray [ "" ]
-    ]
-    |> unbox<FileFilter>
-    |> Array.singleton
-
 
 /// Ask the user to choose a project file, with a dialog window.
 /// Return the folder containing the chosen project file.
 /// Return None if the user exits withouth selecting a path.
 let askForExistingProjectPath (defaultPath: string option) : string option =
     let options = createEmpty<OpenDialogSyncOptions>
-    options.filters <- Some (projectFileFilters |> ResizeArray)
+    options.filters <- Some (makeFileFilters "ISSIE project file" "dprj" |> ResizeArray)
     options.defaultPath <-
         defaultPath
         |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
@@ -324,13 +307,33 @@ let askForExistingProjectPath (defaultPath: string option) : string option =
         | p :: _ -> Some <| dirName p
     )
 
+/// ask for existing sheet paths
+let askForExistingSheetPaths (defaultPath: string option) : string list option =
+    let options = createEmpty<OpenDialogSyncOptions>
+    options.filters <- Some (makeFileFilters "ISSIE sheet" "dgm" |> ResizeArray)
+    options.defaultPath <-
+        defaultPath
+        |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
+        |> Some
+    options.properties <- Some [|
+        OpenDialogOptionsPropertiesArray.MultiSelections
+        |]
+    let w = electronRemote.getCurrentWindow()
+    electronRemote.dialog.showOpenDialogSync(w,options)
+    |> Option.bind (
+        Seq.toList
+        >> function
+        | [] -> None
+        | paths -> Some <| paths
+    )
+
 
 
 /// Ask the user a new project path, with a dialog window.
 /// Return None if the user exits withouth selecting a path.
 let rec askForNewProjectPath (defaultPath:string option) : string option =
     let options = createEmpty<SaveDialogSyncOptions>
-    options.filters <- Some (projectFilters |> ResizeArray)
+    options.filters <- Some (makeFileFilters "ISSIE project" "" |> ResizeArray)
     options.title <- Some "Enter new ISSIE project directory and name"
     options.nameFieldLabel <- Some "New project name"
     options.defaultPath <- defaultPath
@@ -681,7 +684,7 @@ let loadAllComponentFiles (folderPath:string)  =
 /// Return None if the user exits withouth selecting a path.
 let rec askForNewFile (projectPath: string) : string option =
     let options = createEmpty<SaveDialogSyncOptions>
-    options.filters <- Some (ramFileFilters |> ResizeArray)
+    options.filters <- Some (makeFileFilters "Memory Contents File" "ram" |> ResizeArray)
     options.defaultPath <- Some projectPath
     options.title <- Some "Enter new file name"
     options.nameFieldLabel <- Some "New file name"

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -66,10 +66,15 @@ type MemoryEditorData = {
     NumberBase : NumberBase
 }
 
+type ImportDecision =
+    | Overwrite
+    | Rename
+
 /// Possible fields that may (or may not) be used in a dialog popup.
 type PopupDialogData = {
     Text : string option;
     Int : int option;
+    ImportDecisions : Map<string, ImportDecision option>
     Int2: int64 option
     ProjectPath: string
     MemorySetup : (int * int * InitMemData * string option) option // AddressWidth, WordWidth. 
@@ -88,6 +93,7 @@ type PopupDialogData = {
 
 let text_ = Lens.create (fun a -> a.Text) (fun s a -> {a with Text = s})
 let int_ = Lens.create (fun a -> a.Int) (fun s a -> {a with Int = s})
+let importDecisions_ = Lens.create (fun a -> a.ImportDecisions) (fun s a -> {a with ImportDecisions = s})
 let int2_ = Lens.create (fun a -> a.Int2) (fun s a -> {a with Int2 = s})
 let projectPath_ = Lens.create (fun a -> a.ProjectPath) (fun s a -> {a with ProjectPath = s})
 let memorySetup_ = Lens.create (fun a -> a.MemorySetup) (fun s a -> {a with MemorySetup = s})
@@ -121,6 +127,7 @@ type UICommandType =
     | CloseProject
     | ChangeSheet
     | RenameSheet
+    | ImportSheet
     | DeleteSheet
     | AddSheet
     | SaveSheet
@@ -363,6 +370,7 @@ type Msg =
     | SetProject of Project
     | UpdateProject of (Project -> Project)
     | UpdateModel of (Model -> Model)
+    | UpdateImportDecisions of Map<string, ImportDecision option>
     | UpdateProjectWithoutSyncing of (Project->Project)
     | ShowPopup of ((Msg -> Unit) -> Model -> ReactElement)
     | ShowStaticInfoPopup of (string * ReactElement * (Msg -> Unit))

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -87,6 +87,7 @@ let init() = {
     PopupDialogData = {
         ProjectPath = ""
         Text = None
+        ImportDecisions = Map.empty
         Int = None
         Int2 = None
         MemorySetup = None

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -199,6 +199,13 @@ let update (msg : Msg) oldModel =
     | UpdateModel( updateFn: Model -> Model) ->
         updateFn model, Cmd.none
 
+    | UpdateImportDecisions importDecisions' ->
+        let updatedModel = 
+            model
+            |> set (popupDialogData_ >-> importDecisions_) importDecisions'
+       
+        updatedModel, Cmd.none
+
     | RefreshWaveSim ws ->
         // restart the wave simulator after design change etc that invalidates all waves
         WaveSim.refreshWaveSim true ws model
@@ -356,6 +363,7 @@ let update (msg : Msg) oldModel =
             PopupDialogData =
                     { model.PopupDialogData with
                         Text = None;
+                        ImportDecisions = Map.empty;
                         Int = None;
                         Int2 = None;
                         MemorySetup = None;

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -124,7 +124,8 @@ let shortDisplayMsg (msg:Msg) =
     | SetCreateComponent _ -> Some "SetCreateComponent"
     | SetProject _ -> Some "SetProject"
     | UpdateProject _ 
-    | UpdateModel _ 
+    | UpdateModel _
+    | UpdateImportDecisions _
     | UpdateProjectWithoutSyncing _ 
     | ShowPopup _ 
     | ShowStaticInfoPopup _ 


### PR DESCRIPTION
For issue #307 

Users can import sheets within Issie and make decisions to resolve possbile conflicts.

Extensions:
- For sheets that exist in destination dir, compare signature with import sheet. If they don't match, disable overwrite and tell user why
- Offer sheet dependencies for import as well, and tell user if there are any missing. 