### PR TITLE
Import sheet v2

### DIFF
--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -1061,7 +1061,10 @@ let private importSheet model dispatch =
                    
                 let newSheetPath = pathJoin [|projectDir; baseName sheetPath|]
 
-                if existing then exists <| newSheetPath else not (exists <| newSheetPath)
+                if not <| fileNameIsBad (baseNameWithoutExtension <| baseName sheetPath) then
+                    if existing then exists <| newSheetPath else not (exists <| newSheetPath)
+                else
+                    false
                    
             )
 

--- a/src/Renderer/UI/FileMenuView.fs
+++ b/src/Renderer/UI/FileMenuView.fs
@@ -1038,18 +1038,11 @@ let private importSheet model dispatch =
     | Some project -> 
         let projectDir = project.ProjectPath
 
-        (*
-        let printKeyValue key value =
-            printfn "Key--: %s, Value: %A" key value
-
-        Map.iter printKeyValue (getSheetTrees project)
-        *)
-
         dispatch <| (Sheet (SheetT.SetSpinner false))
 
         let importDecisions model = getImportDecisions model.PopupDialogData
 
-        let updateDecisions (sheetPath: string) (decisionOption: ImportDecision option) (model' : Model)=
+        let updateDecisions (sheetPath: string) (decisionOption: ImportDecision option) (model' : Model) =
             let updatedDecisions = Map.add sheetPath decisionOption (importDecisions model')
 
             dispatch <| UpdateImportDecisions updatedDecisions


### PR DESCRIPTION
- Overwrite button disabled if hardware inside sheets is different. This is told to the user.
- If a sheet has dependencies, a warning is disaplyed.
- Fixed a bug that was in original PR, where if backup file is selected, user is shown error popup, but it gets copied over anyway. This meant that the button was broken as long as file was in directory. This has now been fixed.