### PR TITLE
Changed scalingBox functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issie",
-  "version": "4.0.6",
+  "version": "4.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "issie",
-      "version": "4.0.6",
+      "version": "4.0.9",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@electron/remote": "^2",

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -437,6 +437,13 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
         {issieModel with Sheet={ issieModel.Sheet with Wire={model with Wires = newWires}}} |> withNoMsg
     | ToggleSnapToNet ->
         {issieModel with Sheet={ issieModel.Sheet with Wire={model with SnapToNet = not model.SnapToNet}}} |> withNoMsg
+        
+    |> fun (inputModel, inputCmd) -> 
+        match inputModel.Sheet.ScalingBox with 
+        | Some scalingBox when scalingBox.MouseOnScaleButton -> 
+            inputModel, inputCmd
+        | _ -> 
+            {inputModel with Sheet = {inputModel.Sheet with UndoList = inputModel.Sheet :: inputModel.Sheet.UndoList}}, inputCmd
 
 
 //---------------------------------------------------------------------------------//        

--- a/src/Renderer/DrawBlock/RotateScale.fs
+++ b/src/Renderer/DrawBlock/RotateScale.fs
@@ -613,6 +613,7 @@ let scaleBlock (compList:ComponentId list) (model:SymbolT.Model) (scale:ScaleTyp
 let scaleBlockGroup (compList:ComponentId list) (model:SymbolT.Model) (mag:float)=
     //Similar structure to rotateBlock, easy to understand
 
+    printfn "running scaleBlockGroup"
     let SelectedSymbols = List.map (fun x -> model.Symbols |> Map.find x) compList
     let UnselectedSymbols = model.Symbols |> Map.filter (fun x _ -> not (List.contains x compList))
 

--- a/src/Renderer/DrawBlock/SymbolResizeHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolResizeHelpers.fs
@@ -186,6 +186,7 @@ let manualSymbolResize
         (fixedCornerLoc: XYPos) // XYPos of corner opposite that which is clicked - this will not change
         (mPos: XYPos) // XYPos of mouse. Symbol will be resized to make its clicked corner match this
         = 
+    printfn "running manualSymbolResize"
     let symbol = model.Symbols[compId]
     let symPos = get posOfSym_ symbol
     let comp = symbol.Component 

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -409,17 +409,12 @@ module SheetT =
     // HLP 23: AUTHOR Khoury & Ismagilov
     // Types needed for scaling box
     type ScalingBox = {
-        TopLeftStart : XYPos
-        WidthStart : float
-        HeightStart : float
-        StartingPos: XYPos
-        StartingMouse: XYPos
-        ShowBox: bool
-        BoxBound: BoundingBox
-        ScaleButton: SymbolT.Symbol Option
-        RotateCWButton: SymbolT.Symbol Option
-        RotateACWButton: SymbolT.Symbol Option
-        MovingPos: XYPos List
+        ScaleButton: SymbolT.Symbol 
+        RotateCWButton: SymbolT.Symbol 
+        RotateACWButton: SymbolT.Symbol 
+        ScalingBoxBound: BoundingBox
+        MouseOnScaleButton: bool
+        ButtonList: ComponentId list
     }
 
   
@@ -497,7 +492,7 @@ module SheetT =
 
     /// For Keyboard messages
     type KeyboardMsg =
-        | CtrlS | CtrlC | CtrlV | CtrlZ | CtrlY | CtrlA | CtrlW | AltC | AltV | AltZ | AltShiftZ | ZoomIn | ZoomOut | DEL | ESC | CtrlU | CtrlI
+        | CtrlS | CtrlC | CtrlV | CtrlZ | CtrlY | CtrlA | CtrlW | AltC | AltV | AltZ | AltShiftZ | ZoomIn | ZoomOut | DEL | ESC
 
     type WireTypeMsg =
         | Jump | Radiussed | Modern
@@ -548,7 +543,6 @@ module SheetT =
         | ManualKeyDown of string // For manual key-press checking, e.g. CtrlC
         | CheckAutomaticScrolling
         | DoNothing
-        | DrawBox
         // ------------------- Popup Dialog Management Messages----------------------//
         | ShowPopup of ((Msg -> Unit) -> PopupDialogData -> ReactElement)
         | ClosePopup
@@ -618,7 +612,6 @@ module SheetT =
         NearbyComponents: CommonTypes.ComponentId list
         ErrorComponents: CommonTypes.ComponentId list
         DragToSelectBox: BoundingBox
-        ButtonList: ComponentId list
         ConnectPortsLine: XYPos * XYPos // Visual indicator for connecting ports, defines two vertices to draw a line in-between.
         TargetPortId: string // Keeps track of if a target port has been found for connecting two wires in-between.
         Action: CurrentAction
@@ -643,14 +636,14 @@ module SheetT =
         /// html scrolling position: this is in screen pixels, draw block X,Y values are 1/model.Zoom of this
         ScreenScrollPos: XYPos // copies HTML canvas scrolling position: (canvas.scrollLeft,canvas.scrollTop)
         /// this is Drawblock X,Y values
-        LastMousePos: XYPos // For Symbol Movement
+        LastMousePos: XYPos // For Symbol Movement and Scaling
         ScrollingLastMousePos: XYPosMov // For keeping track of mouse movement when scrolling. Can't use LastMousePos as it's used for moving symbols (won't be able to move and scroll symbols at same time)
         LastMousePosForSnap: XYPos
         MouseCounter: int
         CtrlKeyDown : bool
         ScrollUpdateIsOutstanding: bool
         PrevWireSelection : ConnectionId list
-        Box: ScalingBox
+        ScalingBox: ScalingBox Option
         Compiling: bool
         CompilationStatus: CompileStatus
         CompilationProcess: ChildProcess option

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -313,7 +313,7 @@ let getContextMenu (e: Browser.Types.MouseEvent) (model: Model) : string =
             | Some {Component = {Type = Custom ct}} ->
                 DBCustomComp (symbols[compId], ct)
             | Some sym ->
-                DBComp sym
+                if sym.Annotation = None then DBComp sym else NoMenu
         | SheetT.MouseOn.Connection connId, _, _ ->
             Map.tryFind connId bwModel.Wires
             |> function | None ->


### PR DESCRIPTION
- No misplaced scalingBox
- No more breakage when right-click on the buttons on the scalingBox
- No right click on rotation/scaling button when scalingBox appears
- Fixed the following issue: when any of the multiple selected components overlap with unselected components during scaling, after mouse release, it should ideally (now fixed) go back to its original position. Instead, (before fixing) it does the job of scaling to a new position with the overlapped selected components being hidden underneath.