### PR TITLE
Step sim UI (backwards and refresh)

### DIFF
--- a/src/Renderer/DrawBlock/PopupHelpers.fs
+++ b/src/Renderer/DrawBlock/PopupHelpers.fs
@@ -575,6 +575,27 @@ let dialogPopup title body buttonText buttonAction isDisabled extraStyle dispatc
             ]
     dynamicClosablePopup title body foot extraStyle dispatch
 
+// Used for refresh popup
+let dialogPopupRefresh title body extraStyle dispatch =
+    let foot =
+        fun (model: Model) ->
+            let dialogData = model.PopupDialogData
+            Level.level [ Level.Level.Props [ Style [ Width "100%" ] ] ] [
+                Level.left [] []
+                Level.right [] [
+                    Level.item [] [
+                        Button.button [
+                            Button.Color IsLight
+                            Button.OnClick (fun _ -> 
+                                dispatch ClosePopup
+                                dispatch FinishUICmd) 
+                        ] [ str "Cancel" ]
+                    ]
+                ]
+            ]
+    
+    dynamicClosablePopup title body foot extraStyle dispatch
+
 /// Popup with an input textbox and two buttons.
 /// The text is reflected in Model.PopupDialogText.
 let dialogVerilogPopup title body saveUpdateText noErrors showingExtraInfo saveButtonAction moreInfoButton isDisabled extraStyle dispatch =

--- a/src/Renderer/Simulator/Fast/FastReduce.fs
+++ b/src/Renderer/Simulator/Fast/FastReduce.fs
@@ -254,11 +254,15 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     /// get last cycle data from output i for component
     let inline insOldUInt32 i =
         checkInputPortNumber i
-        comp.GetInputUInt32 (simStepOld) (InputPortNumber i)
+        match numStep with
+        | 0 -> 0u
+        | _ -> comp.GetInputUInt32 (simStepOld) (InputPortNumber i)
 
     let inline insOldBigInt i =
         checkInputPortNumber i
-        comp.GetInputBigInt (simStepOld) (InputPortNumber i)
+        match numStep with
+        | 0 -> 0I
+        | _ -> comp.GetInputBigInt (simStepOld) (InputPortNumber i)
 
     /// Write current step output data for output port pn
     let inline putUInt32 pn fd = comp.PutOutputUInt32 (simStep) (OutputPortNumber pn) fd
@@ -328,7 +332,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
     | Constant(width, cVal), true -> putBigInt 0 <| (convertInt64ToBigInt width cVal)
     | Output width, false ->
         let bits = insUInt32 0
-        //printfn "In output bits=%A, ins = %A" bits comp.InputLinks
+        // printfn "In output bits=%A, ins = %A" bits comp.InputLinks
         checkWidth width (comp.InputWidth 0)
         putUInt32 0 bits
     | Output width, true ->


### PR DESCRIPTION
- If inputs have been changed from default, refresh button is still available but will result in confirmation popup
- Backwards button added
- Warning if steps need to be re-simulated as they have been overwritten, will re-run simulation up to selected clock tick
- Display the current clock tick that the simulation has been run up to