### PR TITLE
Add n-way merge and split components

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -248,6 +248,7 @@ module CommonTypes
         | NbitsOr of BusWidth: int | NbitSpreader of BusWidth: int
         | Custom of CustomComponentType // schematic sheet used as component
         | MergeWires | SplitWire of BusWidth: int // int is bus width
+        | MergeN of NumInputs: int * InputWidths: int list
         // DFFE is a DFF with an enable signal.
         // No initial state for DFF or Register? Default 0.
         | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -468,6 +469,7 @@ module CommonTypes
             | NbitsOr of BusWidth: int | NbitSpreader of BusWidth: int
             | Custom of CustomComponentType // schematic sheet used as component
             | MergeWires | SplitWire of BusWidth: int // int is bus width
+            | MergeN of NumInputs: int * InputWidths: int list
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.
             | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -541,6 +543,7 @@ module CommonTypes
             | JSONComponent.ComponentType.NbitSpreader x -> NbitSpreader x
             | JSONComponent.ComponentType.Custom x -> Custom x // schematic sheet used as component
             | JSONComponent.ComponentType.MergeWires -> MergeWires
+            | JSONComponent.ComponentType.MergeN (a, b) -> MergeN (a,b)
             | JSONComponent.ComponentType.SplitWire x -> SplitWire x // int is bus width
             | JSONComponent.ComponentType.DFF -> DFF
             | JSONComponent.ComponentType.DFFE -> DFFE
@@ -600,6 +603,7 @@ module CommonTypes
             | NbitSpreader w -> JSONComponent.ComponentType.NbitSpreader w
             | Custom t -> JSONComponent.ComponentType.Custom t // schematic sheet used as component
             | MergeWires -> JSONComponent.ComponentType.MergeWires
+            | MergeN (a , b) -> JSONComponent.ComponentType.MergeN (a,b)
             | SplitWire w -> JSONComponent.ComponentType.SplitWire w // int is bus width
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -249,6 +249,7 @@ module CommonTypes
         | Custom of CustomComponentType // schematic sheet used as component
         | MergeWires | SplitWire of BusWidth: int // int is bus width
         | MergeN of NumInputs: int
+        | SplitN of NumInputs: int * OutputWdiths: int list * OutputLSBits: int list
         // DFFE is a DFF with an enable signal.
         // No initial state for DFF or Register? Default 0.
         | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -470,6 +471,7 @@ module CommonTypes
             | Custom of CustomComponentType // schematic sheet used as component
             | MergeWires | SplitWire of BusWidth: int // int is bus width
             | MergeN of NumInputs: int
+            | SplitN of NumInputs: int * OutputWdiths: int list * OutputLSBits: int list
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.
             | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -545,6 +547,7 @@ module CommonTypes
             | JSONComponent.ComponentType.MergeWires -> MergeWires
             | JSONComponent.ComponentType.MergeN x -> MergeN x
             | JSONComponent.ComponentType.SplitWire x -> SplitWire x // int is bus width
+            | JSONComponent.ComponentType.SplitN (a, b, c) -> SplitN (a, b, c)
             | JSONComponent.ComponentType.DFF -> DFF
             | JSONComponent.ComponentType.DFFE -> DFFE
             | JSONComponent.ComponentType.Register x -> Register x
@@ -605,6 +608,7 @@ module CommonTypes
             | MergeWires -> JSONComponent.ComponentType.MergeWires
             | MergeN x -> JSONComponent.ComponentType.MergeN x
             | SplitWire w -> JSONComponent.ComponentType.SplitWire w // int is bus width
+            | SplitN (a, b, c) -> JSONComponent.ComponentType.SplitN (a, b, c)
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.
             | DFF -> JSONComponent.ComponentType.DFF

--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -248,7 +248,7 @@ module CommonTypes
         | NbitsOr of BusWidth: int | NbitSpreader of BusWidth: int
         | Custom of CustomComponentType // schematic sheet used as component
         | MergeWires | SplitWire of BusWidth: int // int is bus width
-        | MergeN of NumInputs: int * InputWidths: int list
+        | MergeN of NumInputs: int
         // DFFE is a DFF with an enable signal.
         // No initial state for DFF or Register? Default 0.
         | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -469,7 +469,7 @@ module CommonTypes
             | NbitsOr of BusWidth: int | NbitSpreader of BusWidth: int
             | Custom of CustomComponentType // schematic sheet used as component
             | MergeWires | SplitWire of BusWidth: int // int is bus width
-            | MergeN of NumInputs: int * InputWidths: int list
+            | MergeN of NumInputs: int
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.
             | DFF | DFFE | Register of BusWidth: int | RegisterE of BusWidth: int
@@ -543,7 +543,7 @@ module CommonTypes
             | JSONComponent.ComponentType.NbitSpreader x -> NbitSpreader x
             | JSONComponent.ComponentType.Custom x -> Custom x // schematic sheet used as component
             | JSONComponent.ComponentType.MergeWires -> MergeWires
-            | JSONComponent.ComponentType.MergeN (a, b) -> MergeN (a,b)
+            | JSONComponent.ComponentType.MergeN x -> MergeN x
             | JSONComponent.ComponentType.SplitWire x -> SplitWire x // int is bus width
             | JSONComponent.ComponentType.DFF -> DFF
             | JSONComponent.ComponentType.DFFE -> DFFE
@@ -603,7 +603,7 @@ module CommonTypes
             | NbitSpreader w -> JSONComponent.ComponentType.NbitSpreader w
             | Custom t -> JSONComponent.ComponentType.Custom t // schematic sheet used as component
             | MergeWires -> JSONComponent.ComponentType.MergeWires
-            | MergeN (a , b) -> JSONComponent.ComponentType.MergeN (a,b)
+            | MergeN x -> JSONComponent.ComponentType.MergeN x
             | SplitWire w -> JSONComponent.ComponentType.SplitWire w // int is bus width
             // DFFE is a DFF with an enable signal.
             // No initial state for DFF or Register? Default 0.

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -164,6 +164,7 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
                         | Some 1 ->
                             Map.add symId {symbol with InWidth1 = Some wire.Width} m
                         | x -> failwithf $"What? wire found with input port {x} other than 0 or 1 connecting to MergeWires"
+                    // add MergeN later
                     | _ -> m
 
             let newWires = ((Map.empty, model.Wires) ||> Map.fold addWireWidthFolder)

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -164,18 +164,22 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
                         | Some 1 ->
                             Map.add symId {symbol with InWidth1 = Some wire.Width} m
                         | x -> failwithf $"What? wire found with input port {x} other than 0 or 1 connecting to MergeWires"
-                    // add MergeN later
-                    | MergeN (nInps, _) -> 
+                    | MergeN nInps -> 
                         match inPort.PortNumber with
                         | Some n when (n < nInps && n >= 0) -> 
                             let newInWidths: int option list = 
                                 match symbol.InWidths with
                                 | None -> List.init nInps (fun i -> 
                                     if i = n then Some wire.Width else None)
-                                | Some list -> List.mapi (fun i x -> 
-                                    if i = n then Some wire.Width else x) list
+                                | Some list -> 
+                                    match list.Length with 
+                                    | len when len = nInps ->
+                                        List.mapi (fun i x -> 
+                                            if i = n then Some wire.Width else x) list
+                                    | _ -> List.init nInps (fun i -> 
+                                        if i = n then Some wire.Width else None)
                             Map.add symId {symbol with InWidths = Some newInWidths} m
-                        | x -> failwithf $"What? wire found with input port {x} other than [0..N-1] connecting to MergeN"
+                        | x -> failwithf $"What? wire found with input port {x} other than [0..{nInps-1}] connecting to MergeN"
                     | _ -> m
 
             let newWires = ((Map.empty, model.Wires) ||> Map.fold addWireWidthFolder)

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -165,6 +165,17 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
                             Map.add symId {symbol with InWidth1 = Some wire.Width} m
                         | x -> failwithf $"What? wire found with input port {x} other than 0 or 1 connecting to MergeWires"
                     // add MergeN later
+                    | MergeN (nInps, _) -> 
+                        match inPort.PortNumber with
+                        | Some n when (n < nInps && n >= 0) -> 
+                            let newInWidths: int option list = 
+                                match symbol.InWidths with
+                                | None -> List.init nInps (fun i -> 
+                                    if i = n then Some wire.Width else None)
+                                | Some list -> List.mapi (fun i x -> 
+                                    if i = n then Some wire.Width else x) list
+                            Map.add symId {symbol with InWidths = Some newInWidths} m
+                        | x -> failwithf $"What? wire found with input port {x} other than [0..N-1] connecting to MergeN"
                     | _ -> m
 
             let newWires = ((Map.empty, model.Wires) ||> Map.fold addWireWidthFolder)

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -157,6 +157,11 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
                         | Some 0 -> {symbol with InWidth0 = Some wire.Width}
                         | x -> failwithf $"What? wire found with input port {x} other than 0 connecting to SplitWire"
                         |> (fun sym -> Map.add symId sym m)
+                    | SplitN _ -> 
+                        match inPort.PortNumber with
+                        | Some 0 -> {symbol with InWidth0 = Some wire.Width}
+                        | x -> failwithf $"What? wire found with input port {x} other than 0 connecting to SplitN"
+                        |> (fun sym -> Map.add symId sym m)
                     | MergeWires ->
                         match inPort.PortNumber with
                         | Some 0 ->

--- a/src/Renderer/DrawBlock/PopupHelpers.fs
+++ b/src/Renderer/DrawBlock/PopupHelpers.fs
@@ -410,7 +410,7 @@ let dialogPopupBodyNInts beforeInt numInputsDefault intDefault dispatch =
             setupWidthList
             |> List.mapi (fun index defaultValue ->
                 div [Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.Center]] [
-                    label [Style[MarginRight "10px"]] [str (sprintf "Input Port %d Width :" (index + 1))] 
+                    label [Style[MarginRight "10px"]] [str (sprintf "Input Port %d Width :" index)] 
                     Input.number [
                         Input.Props [OnPaste preventDefault; Style [Width "60px"]; AutoFocus true]
                         Input.DefaultValue <| sprintf "%d" defaultValue
@@ -421,6 +421,7 @@ let dialogPopupBodyNInts beforeInt numInputsDefault intDefault dispatch =
                                     |> List.mapi (fun i x -> if i = index then newWidth else x)
                             getIntEventValue >> setWidth >> Some >> SetPopupDialogIntList >> dispatch)
                     ]
+                    hr []
                 ]
                 )
             |> div [] 

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -153,6 +153,14 @@ module SheetInterface =
             dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
             dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
 
+        /// Given a compId, number of inputs and width list
+        member this.ChangeMergeN (dispatch: Dispatch<Msg>) (compId: ComponentId) (numInputs: int) (widths: int list) =
+            dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeMergeN (compId, numInputs, widths))))
+            let delPorts = SymbolPortHelpers.findDeletedPorts this.Wire.Symbol compId (this.GetComponentById compId) (MergeN (numInputs, widths))
+            dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
+            dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
+            this.DoBusWidthInference dispatch
+
         /// Given a compId and a LSB, update the LSB of the Component specified by compId
         member this.ChangeLSB (dispatch: Dispatch<Msg>) (compId: ComponentId) (lsb: int64) =
             dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeLsb (compId, lsb) ) ) )

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -154,9 +154,9 @@ module SheetInterface =
             dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
 
         /// Given a compId, number of inputs and width list
-        member this.ChangeMergeN (dispatch: Dispatch<Msg>) (compId: ComponentId) (numInputs: int) (widths: int list) =
-            dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeMergeN (compId, numInputs, widths))))
-            let delPorts = SymbolPortHelpers.findDeletedPorts this.Wire.Symbol compId (this.GetComponentById compId) (MergeN (numInputs, widths))
+        member this.ChangeMergeN (dispatch: Dispatch<Msg>) (compId: ComponentId) (numInputs: int) =
+            dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeMergeN (compId, numInputs))))
+            let delPorts = SymbolPortHelpers.findDeletedPorts this.Wire.Symbol compId (this.GetComponentById compId) (MergeN numInputs)
             dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
             dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
             this.DoBusWidthInference dispatch

--- a/src/Renderer/DrawBlock/Sheet.fs
+++ b/src/Renderer/DrawBlock/Sheet.fs
@@ -153,10 +153,18 @@ module SheetInterface =
             dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
             dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
 
-        /// Given a compId, number of inputs and width list
+        /// Given a compId, number of inputs
         member this.ChangeMergeN (dispatch: Dispatch<Msg>) (compId: ComponentId) (numInputs: int) =
             dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeMergeN (compId, numInputs))))
             let delPorts = SymbolPortHelpers.findDeletedPorts this.Wire.Symbol compId (this.GetComponentById compId) (MergeN numInputs)
+            dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
+            dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
+            this.DoBusWidthInference dispatch
+
+        /// Given comId, number of inputs, widths and LSBs
+        member this.ChangeSplitN (dispatch: Dispatch<Msg>) (compId: ComponentId) (numInputs: int) (widths : int list) (lsbs: int list) =
+            dispatch <| (Wire (BusWireT.Symbol (SymbolT.ChangeSplitN (compId, numInputs, widths, lsbs))))
+            let delPorts = SymbolPortHelpers.findDeletedPorts this.Wire.Symbol compId (this.GetComponentById compId) (SplitN (numInputs, widths, lsbs))
             dispatch <| (Wire (BusWireT.DeleteWiresOnPort delPorts))
             dispatch <| (Wire (BusWireT.UpdateSymbolWires compId))
             this.DoBusWidthInference dispatch

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -323,6 +323,7 @@ let getPrefix (compType:ComponentType) =
     | MergeWires -> "MW"
     | MergeN _ -> "MN"
     | SplitWire _ -> "SW"
+    | SplitN _ -> "SN"
     |_  -> ""
 
 
@@ -360,6 +361,7 @@ let getComponentLegend (componentType:ComponentType) (rotation:Rotation) =
     | Shift (n,_,_) -> busTitleAndBits "Shift" n
     | Custom x -> x.Name.ToUpper()
     | MergeN _ -> "Merge"
+    | SplitN _ -> "Split"
     | _ -> ""
 
 
@@ -575,6 +577,11 @@ let getComponentProperties (compType:ComponentType) (label: string)=
             if n < 3 then 3
             else n
         (n , 1, 2.*gS * (float k)/2. , 2.*gS)
+    | SplitN (n, _, _) -> 
+        let k = 
+            if n < 3 then 3
+            else n
+        (1 , n, 2.*gS * (float k)/2. , 2.*gS)
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
@@ -702,7 +709,7 @@ let addToPortModel (model: Model) (sym: Symbol) =
 let inline getPortPosEdgeGap (ct: ComponentType) =
     match ct with
     | MergeWires | SplitWire _  -> 0.25
-    | IsBinaryGate | Mux2 | MergeN _ -> Constants.gatePortPosEdgeGap
+    | IsBinaryGate | Mux2 | MergeN _ | SplitN _ -> Constants.gatePortPosEdgeGap
     | _ -> Constants.portPosEdgeGap
 
 ///Given a symbol and a Port, it returns the orientation of the port

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -570,7 +570,11 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input _ ->
         failwithf "Legacy Input component types should never occur"
     | GateN (_, n) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
-    | MergeN (n, _) -> (n , 1, 2.*gS * (float n)/2. , 2.*gS)
+    | MergeN n -> 
+        let k = 
+            if n < 3 then 3
+            else n
+        (n , 1, 2.*gS * (float k)/2. , 2.*gS)
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -572,12 +572,12 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input _ ->
         failwithf "Legacy Input component types should never occur"
     | GateN (_, n) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
-    | MergeN n -> 
+    | MergeN n -> // make min height so doesn't squash label
         let k = 
             if n < 3 then 3
             else n
         (n , 1, 2.*gS * (float k)/2. , 2.*gS)
-    | SplitN (n, _, _) -> 
+    | SplitN (n, _, _) -> //make min height so doesn't squash label
         let k = 
             if n < 3 then 3
             else n

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -321,6 +321,7 @@ let getPrefix (compType:ComponentType) =
     | Counter _ |CounterNoEnable _
     | CounterNoLoad _ |CounterNoEnableLoad _ -> "CNT"
     | MergeWires -> "MW"
+    | MergeN _ -> "MN"
     | SplitWire _ -> "SW"
     |_  -> ""
 
@@ -358,6 +359,7 @@ let getComponentLegend (componentType:ComponentType) (rotation:Rotation) =
     | NbitsNot (x)->  nBitsGateTitle "NOT" x
     | Shift (n,_,_) -> busTitleAndBits "Shift" n
     | Custom x -> x.Name.ToUpper()
+    | MergeN _ -> "Merge"
     | _ -> ""
 
 
@@ -568,7 +570,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input _ ->
         failwithf "Legacy Input component types should never occur"
     | GateN (_, n) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
-    | MergeN (n, _) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
+    | MergeN (n, _) -> (n , 1, 1.5*gS * (float n)/2. , 2.0*gS)
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
@@ -665,6 +667,7 @@ let createNewSymbol (ldcs: LoadedComponent list) (pos: XYPos) (comptype: Compone
           }
       InWidth0 = None // set by BusWire
       InWidth1 = None
+      InWidths = None
       Id = ComponentId id
       Component = comp
       Moving = false

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -568,6 +568,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input _ ->
         failwithf "Legacy Input component types should never occur"
     | GateN (_, n) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
+    | MergeN (n, _) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -570,7 +570,7 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Input _ ->
         failwithf "Legacy Input component types should never occur"
     | GateN (_, n) -> (n , 1, 1.5*gS * (float n)/2. , 1.5*gS)
-    | MergeN (n, _) -> (n , 1, 1.5*gS * (float n)/2. , 2.0*gS)
+    | MergeN (n, _) -> (n , 1, 2.*gS * (float n)/2. , 2.*gS)
     | Not -> ( 1 , 1, 1.0*gS ,  1.0*gS) 
     | Input1 _ -> ( 0 , 1, gS ,  2.*gS)                
     | ComponentType.Output (a) -> (  1 , 0, gS ,  2.*gS) 
@@ -698,7 +698,7 @@ let addToPortModel (model: Model) (sym: Symbol) =
 let inline getPortPosEdgeGap (ct: ComponentType) =
     match ct with
     | MergeWires | SplitWire _  -> 0.25
-    | IsBinaryGate | Mux2 -> Constants.gatePortPosEdgeGap
+    | IsBinaryGate | Mux2 | MergeN _ -> Constants.gatePortPosEdgeGap
     | _ -> Constants.portPosEdgeGap
 
 ///Given a symbol and a Port, it returns the orientation of the port

--- a/src/Renderer/DrawBlock/SymbolPortHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolPortHelpers.fs
@@ -28,7 +28,7 @@ let findDeletedPorts (symModel: Model) (compId: ComponentId) (oldComp:Component)
         |GateN (_, n1), GateN (_, n2) when n2 < n1 ->
             symbol.Component.InputPorts[n2..]
             |> List.map (fun x -> x.Id)
-        | MergeN (n1, _), MergeN (n2, _) when n2 < n1 ->
+        | MergeN n1, MergeN n2 when n2 < n1 ->
             symbol.Component.InputPorts[n2..]
             |> List.map (fun x -> x.Id)
         |_,_ -> []

--- a/src/Renderer/DrawBlock/SymbolPortHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolPortHelpers.fs
@@ -28,6 +28,9 @@ let findDeletedPorts (symModel: Model) (compId: ComponentId) (oldComp:Component)
         |GateN (_, n1), GateN (_, n2) when n2 < n1 ->
             symbol.Component.InputPorts[n2..]
             |> List.map (fun x -> x.Id)
+        | MergeN (n1, _), MergeN (n2, _) when n2 < n1 ->
+            symbol.Component.InputPorts[n2..]
+            |> List.map (fun x -> x.Id)
         |_,_ -> []
     removedIds
     |> List.map (fun x -> Map.tryFind x symModel.Ports)

--- a/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
@@ -346,12 +346,13 @@ let changeGateComponent (symModel: Model) (compId: ComponentId) (gateType: GateC
         set h_ (1.5*(float Constants.gridSize) * (float n)/2.)
         )
 
-let changeMergeNComponent (symModel: Model) (compId: ComponentId) (numInputs: int) (widths: int list) =
+let changeMergeNComponent (symModel: Model) (compId: ComponentId) (numInputs: int) =
+    let numInputsEdit = if numInputs > 2 then numInputs else 3
     Map.find compId symModel.Symbols
     |> varyNumberOfPorts PortType.Input numInputs 1
     |> map component_ (
-        set type_ (MergeN (numInputs, widths)) >>
-        set h_ (2.*(float Constants.gridSize) * (float numInputs)/2.)
+        set type_ (MergeN numInputs) >>
+        set h_ (2.*(float Constants.gridSize) * (float numInputsEdit)/2.)
         )
 
 

--- a/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
@@ -346,5 +346,13 @@ let changeGateComponent (symModel: Model) (compId: ComponentId) (gateType: GateC
         set h_ (1.5*(float Constants.gridSize) * (float n)/2.)
         )
 
+let changeMergeNComponent (symModel: Model) (compId: ComponentId) (numInputs: int) (widths: int list) =
+    Map.find compId symModel.Symbols
+    |> varyNumberOfPorts PortType.Input numInputs 1
+    |> map component_ (
+        set type_ (MergeN (numInputs, widths)) >>
+        set h_ (1.5*(float Constants.gridSize) * (float numInputs)/2.)
+        )
+
 
 

--- a/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
@@ -351,7 +351,7 @@ let changeMergeNComponent (symModel: Model) (compId: ComponentId) (numInputs: in
     |> varyNumberOfPorts PortType.Input numInputs 1
     |> map component_ (
         set type_ (MergeN (numInputs, widths)) >>
-        set h_ (1.5*(float Constants.gridSize) * (float numInputs)/2.)
+        set h_ (2.*(float Constants.gridSize) * (float numInputs)/2.)
         )
 
 

--- a/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
+++ b/src/Renderer/DrawBlock/SymbolReplaceHelpers.fs
@@ -143,7 +143,10 @@ let addNumberPort (pType: PortType) (pNum: int) (sym: Symbol) (edgeOpt: Edge opt
             sym.Component.OutputPorts[..pNum-1] @ [newPort] @ List.map portNoUp sym.Component.OutputPorts[pNum..]
     let insertIndex =
         match sym.STransform.flipped with
-        | false -> pNum
+        | false -> 
+            match pType with
+            | PortType.Input -> pNum
+            | PortType.Output -> 0
         | true ->
             match pType with
             | PortType.Input -> sym.Component.InputPorts.Length - 1 - pNum
@@ -352,6 +355,15 @@ let changeMergeNComponent (symModel: Model) (compId: ComponentId) (numInputs: in
     |> varyNumberOfPorts PortType.Input numInputs 1
     |> map component_ (
         set type_ (MergeN numInputs) >>
+        set h_ (2.*(float Constants.gridSize) * (float numInputsEdit)/2.)
+        )
+
+let changeSplitNComponent (symModel: Model) (compId: ComponentId) (numOutputs: int) (widths: int list) (lsbs: int list)=
+    let numInputsEdit = if numOutputs > 2 then numOutputs else 3
+    Map.find compId symModel.Symbols
+    |> varyNumberOfPorts PortType.Output 1  numOutputs
+    |> map component_ (
+        set type_ (SplitN (numOutputs, widths, lsbs)) >>
         set h_ (2.*(float Constants.gridSize) * (float numInputsEdit)/2.)
         )
 

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -791,6 +791,12 @@ let update (msg : Msg) (model : Model): Model*Cmd<'a>  =
         let newModel = {model with Ports = newPorts}  
         (replaceSymbol newModel newSymbol compId), Cmd.none
 
+    | ChangeSplitN (compId, numInputs, widths, lsbs) ->
+        let newSymbol = changeSplitNComponent model compId numInputs widths lsbs
+        let newPorts = addToPortModel model newSymbol
+        let newModel = {model with Ports = newPorts}  
+        (replaceSymbol newModel newSymbol compId), Cmd.none
+
     | ResetModel -> 
         { model with Symbols = Map.empty; Ports = Map.empty; }, Cmd.none
     

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -471,6 +471,7 @@ let createSymbolRecord ldcs theme comp =
             Moving = false
             InWidth0 = None
             InWidth1 = None
+            InWidths = None
             STransform = getSTransformWithDefault comp.SymbolInfo
             ReversedInputPorts = match comp.SymbolInfo with |Some si -> si.ReversedInputPorts |_ -> None
             PortMaps = portMaps
@@ -780,6 +781,12 @@ let update (msg : Msg) (model : Model): Model*Cmd<'a>  =
 
     | ChangeGate (compId, gateType, numInputs) ->
         let newSymbol = changeGateComponent model compId gateType numInputs
+        let newPorts = addToPortModel model newSymbol
+        let newModel = {model with Ports = newPorts}  
+        (replaceSymbol newModel newSymbol compId), Cmd.none
+    
+    | ChangeMergeN (compId, numInputs, widths) ->
+        let newSymbol = changeMergeNComponent model compId numInputs widths
         let newPorts = addToPortModel model newSymbol
         let newModel = {model with Ports = newPorts}  
         (replaceSymbol newModel newSymbol compId), Cmd.none

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -785,8 +785,8 @@ let update (msg : Msg) (model : Model): Model*Cmd<'a>  =
         let newModel = {model with Ports = newPorts}  
         (replaceSymbol newModel newSymbol compId), Cmd.none
     
-    | ChangeMergeN (compId, numInputs, widths) ->
-        let newSymbol = changeMergeNComponent model compId numInputs widths
+    | ChangeMergeN (compId, numInputs) ->
+        let newSymbol = changeMergeNComponent model compId numInputs
         let newPorts = addToPortModel model newSymbol
         let newModel = {model with Ports = newPorts}  
         (replaceSymbol newModel newSymbol compId), Cmd.none

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -349,15 +349,14 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             let modinputTextPoints = Array.map (fun pos -> pos + {X = -18.; Y = 5.}) inputTextPoints
             let outputTextPoints = Array.map (getPortPos symbol) (List.toArray comp.OutputPorts)
             let modOutputTextPoints = Array.map (fun pos -> pos + {X = 18.; Y = 5.}) outputTextPoints
-            let textPoints = rotatePoints (Array.append modinputTextPoints modOutputTextPoints) {X=W/2.;Y=H/2.} transform
-            textPoints
+            Array.append modinputTextPoints modOutputTextPoints
+            
         let splitNTextPos = 
             let inputTextPoints = Array.map (getPortPos symbol) (List.toArray comp.InputPorts)
             let modinputTextPoints = Array.map (fun pos -> pos + {X = -18.; Y = 5.}) inputTextPoints
             let outputTextPoints = Array.map (getPortPos symbol) (List.toArray comp.OutputPorts)
             let modOutputTextPoints = Array.map (fun pos -> pos + {X = -18.; Y = -5.}) outputTextPoints
-            let textPoints = rotatePoints (Array.append modinputTextPoints modOutputTextPoints) {X=W/2.;Y=H/2.} transform
-            textPoints
+            Array.append modinputTextPoints modOutputTextPoints
         match comp.Type with
         | MergeWires -> 
             let lo, hi = 

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -351,6 +351,13 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             let modOutputTextPoints = Array.map (fun pos -> pos + {X = 18.; Y = 5.}) outputTextPoints
             let textPoints = rotatePoints (Array.append modinputTextPoints modOutputTextPoints) {X=W/2.;Y=H/2.} transform
             textPoints
+        let splitNTextPos = 
+            let inputTextPoints = Array.map (getPortPos symbol) (List.toArray comp.InputPorts)
+            let modinputTextPoints = Array.map (fun pos -> pos + {X = -18.; Y = 5.}) inputTextPoints
+            let outputTextPoints = Array.map (getPortPos symbol) (List.toArray comp.OutputPorts)
+            let modOutputTextPoints = Array.map (fun pos -> pos + {X = -18.; Y = -5.}) outputTextPoints
+            let textPoints = rotatePoints (Array.append modinputTextPoints modOutputTextPoints) {X=W/2.;Y=H/2.} transform
+            textPoints
         match comp.Type with
         | MergeWires -> 
             let lo, hi = 
@@ -410,6 +417,20 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                         splitWiresTextPos[i] 
                         (fst values[i]) 
                         (snd values[i])) [] [0..2]
+        | SplitN (n, widths, lsbs) -> 
+            let msbs = 
+                List.map2 (fun width lsb -> 
+                    lsb + width - 1) widths lsbs
+            let inputValue =     
+                match symbol.InWidth0 with
+                | Some width when width > (List.max msbs) ->  (width-1, 0)
+                | _ -> (-2, -1)
+            let values = 
+                List.fold2 (fun acc lsb msb -> 
+                    List.append acc [(msb, lsb)]) [inputValue] lsbs msbs
+            List.fold2 (fun og pos value -> 
+                        og @ mergeSplitLine pos (fst value) (snd value)) [] (Array.toList splitNTextPos) values
+            
         | DFF | DFFE | Register _ |RegisterE _ | ROM1 _ |RAM1 _ | AsyncRAM1 _ | Counter _ | CounterNoEnable _ | CounterNoLoad _ | CounterNoEnableLoad _  -> 
             (addText clockTxtPos " clk" "middle" "normal" "12px")
         | BusSelection(nBits,lsb) ->           

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -360,6 +360,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                         mergeWiresTextPos[i] 
                         (fst values[i]) 
                         (snd values[i])) [] [0..2]
+        // add MergeN later
         | NbitSpreader n -> 
             //let lo = 1
             //let msb = hi + lo - 1
@@ -472,6 +473,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             | 1, 1, _ -> {X = 0.; Y = Constants.legendVertOffset * (if vertFlip then 0.5 else -3.)}
             | 0, 0, _ -> {X = 0.; Y = 0.}
             | 1, 0, _ -> {X = 10.; Y = 0.}
+            | _, _, MergeN _ -> {X=0;Y=0}
             | 0, 1, _ -> {X = -10.; Y = 0.}
             | _ -> failwithf "What? Can't happen"
 

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -471,9 +471,9 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             | _, _, Not -> {X=0;Y=0}
             | _, _, IsBinaryGate -> {X=0;Y=0}
             | 1, 1, _ -> {X = 0.; Y = Constants.legendVertOffset * (if vertFlip then 0.5 else -3.)}
+            | 0, 1, MergeN _ -> {X = 0.; Y = Constants.legendVertOffset *1.6* (if vertFlip then 0.5 else -3.)}
             | 0, 0, _ -> {X = 0.; Y = 0.}
             | 1, 0, _ -> {X = 10.; Y = 0.}
-            | _, _, MergeN _ -> {X=0;Y=0}
             | 0, 1, _ -> {X = -10.; Y = 0.}
             | _ -> failwithf "What? Can't happen"
 

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -260,6 +260,7 @@ module SymbolT =
         | ChangeCounterComponent of compId: ComponentId * oldComp: Component * newComp: ComponentType
         | ChangeGate of compId: ComponentId * gateType: GateComponentType * numInputs: int
         | ChangeMergeN of compId: ComponentId * numInputs: int
+        | ChangeSplitN of compId: ComponentId * numInputs: int * widths: int list * lsbs: int list
         | ResetModel // For Issie Integration
         | LoadComponents of  LoadedComponent list * Component list // For Issie Integration
         | WriteMemoryLine of ComponentId * int64 * int64 // For Issie Integration 

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -132,6 +132,9 @@ module SymbolT =
             InWidth0: int option
             InWidth1: int option
 
+            /// for MergeN later
+            InWidths: int list option
+
             /// the following fields define the position and size of the component label.
             /// labels will rotate when the symbol is rotated.
             /// labels can be manually adjusted, if not position is as default (for given rotation)
@@ -256,6 +259,7 @@ module SymbolT =
         | ChangeAdderComponent of compId: ComponentId * oldComp: Component * newComp: ComponentType
         | ChangeCounterComponent of compId: ComponentId * oldComp: Component * newComp: ComponentType
         | ChangeGate of compId: ComponentId * gateType: GateComponentType * numInputs: int
+        | ChangeMergeN of compId: ComponentId * numInputs: int * widths: int list
         | ResetModel // For Issie Integration
         | LoadComponents of  LoadedComponent list * Component list // For Issie Integration
         | WriteMemoryLine of ComponentId * int64 * int64 // For Issie Integration 

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -133,7 +133,7 @@ module SymbolT =
             InWidth1: int option
 
             /// for MergeN later
-            InWidths: int list option
+            InWidths: int option list option
 
             /// the following fields define the position and size of the component label.
             /// labels will rotate when the symbol is rotated.

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -259,7 +259,7 @@ module SymbolT =
         | ChangeAdderComponent of compId: ComponentId * oldComp: Component * newComp: ComponentType
         | ChangeCounterComponent of compId: ComponentId * oldComp: Component * newComp: ComponentType
         | ChangeGate of compId: ComponentId * gateType: GateComponentType * numInputs: int
-        | ChangeMergeN of compId: ComponentId * numInputs: int * widths: int list
+        | ChangeMergeN of compId: ComponentId * numInputs: int
         | ResetModel // For Issie Integration
         | LoadComponents of  LoadedComponent list * Component list // For Issie Integration
         | WriteMemoryLine of ComponentId * int64 * int64 // For Issie Integration 

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -90,6 +90,7 @@ type PopupDialogData = {
     VerilogErrors: ErrorInfo list
     BadLabel: bool
     IntList: int list option;
+    IntList2: int list option;
 }
 
 let text_ = Lens.create (fun a -> a.Text) (fun s a -> {a with Text = s})
@@ -110,7 +111,7 @@ let verilogCode_ = Lens.create (fun a -> a.VerilogCode) (fun s a -> {a with Veri
 let verilogErrors_ = Lens.create (fun a -> a.VerilogErrors) (fun s a -> {a with VerilogErrors = s})
 let badLabel_ = Lens.create (fun a -> a.BadLabel) (fun s a -> {a with BadLabel = s})
 let intlist_ = Lens.create (fun a -> a.IntList) (fun s a -> {a with IntList = s})
-
+let intlist2_ = Lens.create (fun a -> a.IntList2) (fun s a -> {a with IntList2 = s})
 type TopMenu = | Closed | Project | Files
 
 //==========//
@@ -383,6 +384,7 @@ type Msg =
     | SetPopupDialogInt2 of int64 option
     | SetPopupDialogTwoInts of (int64 option * IntMode * string option)
     | SetPopupDialogIntList of int list option
+    | SetPopupDialogIntList2 of int list option
     | SetPropertiesExtraDialogText of string option
     | SetPopupDialogMemorySetup of (int * int * InitMemData * string option) option
     | SetPopupMemoryEditorData of MemoryEditorData option

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -89,6 +89,7 @@ type PopupDialogData = {
     VerilogCode: string option
     VerilogErrors: ErrorInfo list
     BadLabel: bool
+    IntList: int list option;
 }
 
 let text_ = Lens.create (fun a -> a.Text) (fun s a -> {a with Text = s})
@@ -108,8 +109,7 @@ let algebraError_ = Lens.create (fun a -> a.AlgebraError) (fun s a -> {a with Al
 let verilogCode_ = Lens.create (fun a -> a.VerilogCode) (fun s a -> {a with VerilogCode = s})
 let verilogErrors_ = Lens.create (fun a -> a.VerilogErrors) (fun s a -> {a with VerilogErrors = s})
 let badLabel_ = Lens.create (fun a -> a.BadLabel) (fun s a -> {a with BadLabel = s})
-
-
+let intlist_ = Lens.create (fun a -> a.IntList) (fun s a -> {a with IntList = s})
 
 type TopMenu = | Closed | Project | Files
 
@@ -382,6 +382,7 @@ type Msg =
     | SetPopupDialogInt of int option
     | SetPopupDialogInt2 of int64 option
     | SetPopupDialogTwoInts of (int64 option * IntMode * string option)
+    | SetPopupDialogIntList of int list option
     | SetPropertiesExtraDialogText of string option
     | SetPopupDialogMemorySetup of (int * int * InitMemData * string option) option
     | SetPopupMemoryEditorData of MemoryEditorData option

--- a/src/Renderer/Simulator/Builder.fs
+++ b/src/Renderer/Simulator/Builder.fs
@@ -135,6 +135,7 @@ let private getDefaultState compType =
     | NbitsNot _
     | Custom _
     | MergeWires
+    | MergeN _
     | SplitWire _
     | ROM1 _
     | Viewer _

--- a/src/Renderer/Simulator/Builder.fs
+++ b/src/Renderer/Simulator/Builder.fs
@@ -137,6 +137,7 @@ let private getDefaultState compType =
     | MergeWires
     | MergeN _
     | SplitWire _
+    | SplitN _
     | ROM1 _
     | Viewer _
     | NbitsAdderNoCin _

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -68,6 +68,7 @@ let portNames (componentType:ComponentType)  = //(input port names, output port 
     | DFF -> (["D"],["Q"])
     | DFFE -> (["D";"EN"],["Q"])
     | Mux2 -> (["0"; "1";"SEL"],["OUT"])
+    | MergeN (nInp, _) -> (List.init nInp (fun i -> sprintf "%d" i), ["OUT"])
     | Mux4 -> (["0"; "1"; "2"; "3" ;"SEL"],["OUT"])
     | Mux8 -> (["0"; "1"; "2" ; "3" ; "4" ; "5" ; "6" ; "7";"SEL"],["OUT"])
     | Demux2 -> (["DATA" ; "SEL"],["0"; "1"])

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -68,7 +68,11 @@ let portNames (componentType:ComponentType)  = //(input port names, output port 
     | DFF -> (["D"],["Q"])
     | DFFE -> (["D";"EN"],["Q"])
     | Mux2 -> (["0"; "1";"SEL"],["OUT"])
-    | MergeN (nInp, _) -> (List.init nInp (fun i -> sprintf "%d" i), ["OUT"])
+    | MergeN nInp -> (List.init nInp (fun i -> 
+        match i with
+        | n when n = 0 -> "LSB"
+        | n when n = nInp-1 -> "MSB"
+        | _ -> ""), ["OUT"])
     | Mux4 -> (["0"; "1"; "2"; "3" ;"SEL"],["OUT"])
     | Mux8 -> (["0"; "1"; "2" ; "3" ; "4" ; "5" ; "6" ; "7";"SEL"],["OUT"])
     | Demux2 -> (["DATA" ; "SEL"],["0"; "1"])

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -73,6 +73,7 @@ let portNames (componentType:ComponentType)  = //(input port names, output port 
         | n when n = 0 -> "LSB"
         | n when n = nInp-1 -> "MSB"
         | _ -> ""), ["OUT"])
+    | SplitN (n, _, _) -> (["IN"], [])
     | Mux4 -> (["0"; "1"; "2"; "3" ;"SEL"],["OUT"])
     | Mux8 -> (["0"; "1"; "2" ; "3" ; "4" ; "5" ; "6" ; "7";"SEL"],["OUT"])
     | Demux2 -> (["DATA" ; "SEL"],["0"; "1"])

--- a/src/Renderer/Simulator/Fast/FastCreate.fs
+++ b/src/Renderer/Simulator/Fast/FastCreate.fs
@@ -107,6 +107,7 @@ let getPortNumbers (sc: SimulationComponent) =
         // | Xnor -> 2, 1
         | GateN (_, n) -> n, 1
         | MergeN n -> n, 1
+        | SplitN (n, _, _) -> 1, n
         | Custom ct -> ct.InputLabels.Length, ct.OutputLabels.Length
         | AsyncROM _
         | RAM _
@@ -174,6 +175,13 @@ let findBigIntState (fc: FastComponent) =
         Some 
             { InputIsBigInt = Array.ofList(List.map (fun n -> fc.InputWidth n > 32) [0..n-1])
               OutputIsBigInt = [| fc.OutputWidth 0 > 32 |] }
+    | SplitN (n, _, _) -> 
+        fc.InputWidth 0 > 32
+        || List.exists (fun n -> fc.OutputWidth n > 32) [0..n-1], 
+        Some { 
+            InputIsBigInt = [| fc.InputWidth 0 > 32 |] 
+            OutputIsBigInt = Array.ofList(List.map (fun n -> fc.OutputWidth n > 32) [0..n-1])
+                }
     | SplitWire _ ->
         fc.InputWidth 0 > 32,
         Some
@@ -452,6 +460,7 @@ let addComponentWaveDrivers (f: FastSimulation) (fc: FastComponent) (pType: Port
             | BusSelection _
             | MergeWires
             | MergeN _
+            | SplitN _
             | Constant1 _ -> [||]
             | Output _ when fc.SubSheet <> [] -> [||]
             | Input1 _ when fc.SubSheet <> [] -> [||]

--- a/src/Renderer/Simulator/Fast/FastCreate.fs
+++ b/src/Renderer/Simulator/Fast/FastCreate.fs
@@ -106,7 +106,7 @@ let getPortNumbers (sc: SimulationComponent) =
         // | Nor
         // | Xnor -> 2, 1
         | GateN (_, n) -> n, 1
-        | MergeN (n, _) -> n, 1
+        | MergeN n -> n, 1
         | Custom ct -> ct.InputLabels.Length, ct.OutputLabels.Length
         | AsyncROM _
         | RAM _
@@ -168,11 +168,11 @@ let findBigIntState (fc: FastComponent) =
         Some
             { InputIsBigInt = [| fc.InputWidth 0 > 32; fc.InputWidth 1 > 32 |]
               OutputIsBigInt = [| fc.OutputWidth 0 > 32 |] }
-    | MergeN (_, widths)-> 
+    | MergeN n -> 
         fc.OutputWidth 0 > 32
-        || List.exists (fun width -> width > 32) widths,
+        || List.exists (fun n -> fc.InputWidth n > 32) [0..n-1],
         Some 
-            { InputIsBigInt = Array.ofList(List.map (fun width -> width > 32) widths)
+            { InputIsBigInt = Array.ofList(List.map (fun n -> fc.InputWidth n > 32) [0..n-1])
               OutputIsBigInt = [| fc.OutputWidth 0 > 32 |] }
     | SplitWire _ ->
         fc.InputWidth 0 > 32,

--- a/src/Renderer/Simulator/Fast/FastCreate.fs
+++ b/src/Renderer/Simulator/Fast/FastCreate.fs
@@ -106,6 +106,7 @@ let getPortNumbers (sc: SimulationComponent) =
         // | Nor
         // | Xnor -> 2, 1
         | GateN (_, n) -> n, 1
+        | MergeN (n, _) -> n, 1
         | Custom ct -> ct.InputLabels.Length, ct.OutputLabels.Length
         | AsyncROM _
         | RAM _
@@ -166,6 +167,12 @@ let findBigIntState (fc: FastComponent) =
         || fc.OutputWidth 0 > 32,
         Some
             { InputIsBigInt = [| fc.InputWidth 0 > 32; fc.InputWidth 1 > 32 |]
+              OutputIsBigInt = [| fc.OutputWidth 0 > 32 |] }
+    | MergeN (_, widths)-> 
+        fc.OutputWidth 0 > 32
+        || List.exists (fun width -> width > 32) widths,
+        Some 
+            { InputIsBigInt = Array.ofList(List.map (fun width -> width > 32) widths)
               OutputIsBigInt = [| fc.OutputWidth 0 > 32 |] }
     | SplitWire _ ->
         fc.InputWidth 0 > 32,
@@ -444,6 +451,7 @@ let addComponentWaveDrivers (f: FastSimulation) (fc: FastComponent) (pType: Port
             | SplitWire _
             | BusSelection _
             | MergeWires
+            | MergeN _
             | Constant1 _ -> [||]
             | Output _ when fc.SubSheet <> [] -> [||]
             | Input1 _ when fc.SubSheet <> [] -> [||]

--- a/src/Renderer/Simulator/Fast/FastReduce.fs
+++ b/src/Renderer/Simulator/Fast/FastReduce.fs
@@ -2158,6 +2158,7 @@ let fastReduceFData (maxArraySize: int) (numStep: int) (isClockedReduction: bool
             let exp0, exp1 = fd0.toExp, fd1.toExp
             let newExp = [ exp1; exp0 ] |> foldAppends |> AppendExp
             put 0 <| Alg newExp
+    //add MergeN
 
     | SplitWire topWireWidth ->
         let fd = ins 0

--- a/src/Renderer/Simulator/SynchronousUtils.fs
+++ b/src/Renderer/Simulator/SynchronousUtils.fs
@@ -36,6 +36,7 @@ let couldBeSynchronousComponent compType : bool =
     | BusCompare _
     | BusCompare1 _
     | MergeWires
+    | MergeN _
     | SplitWire _
     | Not
     | Shift _
@@ -100,6 +101,7 @@ let rec hasSynchronousComponents graph : bool =
         | BusCompare _
         | BusCompare1 _
         | MergeWires
+        | MergeN _
         | SplitWire _
         | Not
         // | And

--- a/src/Renderer/Simulator/SynchronousUtils.fs
+++ b/src/Renderer/Simulator/SynchronousUtils.fs
@@ -37,6 +37,7 @@ let couldBeSynchronousComponent compType : bool =
     | BusCompare1 _
     | MergeWires
     | MergeN _
+    | SplitN _
     | SplitWire _
     | Not
     | Shift _
@@ -103,6 +104,7 @@ let rec hasSynchronousComponents graph : bool =
         | MergeWires
         | MergeN _
         | SplitWire _
+        | SplitN _
         | Not
         // | And
         // | Or

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -540,6 +540,13 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
 
         $"assign %s{outs 0} = %s{ins 0}[%d{lsbBits - 1}:0];\n"
         + $"assign %s{outs 1} = %s{ins 0}[%d{msbBits + lsbBits - 1}:%d{lsbBits}];\n"
+    | SplitN (n, outputWidths, lsBits) -> 
+        List.map3 (
+            fun index width lsb -> 
+                let msb = width+lsb-1
+                $"assign %s{outs index} = %s{ins 0}[%d{msb}:%d{lsb}];\n"
+        ) [0..n-1] outputWidths lsBits
+        |> List.fold (fun accstr outstr -> accstr+outstr) ""
     | AsyncROM1 mem -> sprintf $"%s{name} I{idNum} (%s{outs 0}, %s{ins 0});\n"
     | ROM1 mem -> $"%s{name} I{idNum} (%s{outs 0}, %s{ins 0}, clk);\n"
     | RAM1 mem | AsyncRAM1 mem -> $"%s{name} I{idNum} (%s{outs 0}, %s{ins 0}, %s{ins 1}, %s{ins 2}, clk);\n"

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -524,7 +524,7 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
     | BusCompare (w, c) -> $"assign %s{outs 0} = %s{ins 0} == %s{makeBits w (uint64 (uint32 c))};\n"
     | BusCompare1 (w, c, _) -> $"assign %s{outs 0} = %s{ins 0} == %s{makeBits w (uint64 (uint32 c))};\n"
     | MergeWires -> $"assign {outs 0} = {{ {ins 1},{ins 0} }};\n" 
-    | MergeN (n, _)->  
+    | MergeN n ->  
         let mergedInputs = 
             [| for i in n - 1 .. -1 .. 0 ->
                 if i = 0 then

--- a/src/Renderer/Simulator/Verilog.fs
+++ b/src/Renderer/Simulator/Verilog.fs
@@ -523,7 +523,17 @@ let getVerilogComponent (fs: FastSimulation) (fc: FastComponent) =
         $"assign {outs 0} = {ins 0}{sel};\n"
     | BusCompare (w, c) -> $"assign %s{outs 0} = %s{ins 0} == %s{makeBits w (uint64 (uint32 c))};\n"
     | BusCompare1 (w, c, _) -> $"assign %s{outs 0} = %s{ins 0} == %s{makeBits w (uint64 (uint32 c))};\n"
-    | MergeWires -> $"assign {outs 0} = {{ {ins 1},{ins 0} }};\n"  
+    | MergeWires -> $"assign {outs 0} = {{ {ins 1},{ins 0} }};\n" 
+    | MergeN (n, _)->  
+        let mergedInputs = 
+            [| for i in n - 1 .. -1 .. 0 ->
+                if i = 0 then
+                    $"{ins i}"
+                else
+                    $"{ins i},"
+            |]
+            |> String.concat ""
+        $"assign {outs 0} = {{ {mergedInputs} }};\n" 
     | SplitWire _ ->
         let lsbBits = outW 0
         let msbBits = outW 1

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -257,28 +257,28 @@ let private createMergeNPopup (model: Model) dispatch =
             intIn < 2
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
-(*
+
 let private createSplitNPopup (model: Model) dispatch =
-    let title = $"Add N input merge"
+    let title = $"Add N output split"
     let beforeInt =
-        fun _ -> str "How many inputs should the merge component have?"
+        fun _ -> str "How many outputs should the split component have?"
     let numInputsDefault = 2
-    let intDefault = 1
-    let body = dialogPopupBodyNInts beforeInt numInputsDefault intDefault dispatch
+    let body = dialogPopupBodyNInts beforeInt numInputsDefault 1 dispatch
     let buttonText = "Add"
     let buttonAction =
         fun (model': Model) ->
             let dialogData = model'.PopupDialogData
-            let inputInt = getInt dialogData 
-            let inputList = getIntList dialogData numInputsDefault intDefault
-            createCompStdLabel (MergeN (inputInt, inputList)) model dispatch
+            let outputInt = getInt dialogData 
+            let outputWidthList = getIntList dialogData numInputsDefault 1
+            let outputLSBList = getIntList2 dialogData numInputsDefault 0
+            createCompStdLabel (SplitN (outputInt, outputWidthList, outputLSBList)) model dispatch
             dispatch ClosePopup
     let isDisabled =
         fun (model': Model) ->
             let intIn = getInt model'.PopupDialogData
             intIn < 2
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
-*)
+
 
 let private createNbitsAdderPopup (model:Model) dispatch =
     let title = sprintf "Add N bits adder"
@@ -913,6 +913,8 @@ let viewCatalogue model dispatch =
                                                                                              bits of a bus into two sets. \
                                                                                              Default has LS bits connected to top arm. Use Edit -> Flip Vertically \
                                                                                              after placing component to change this."
+                        catTip1 "SplitN" (fun _ -> createSplitNPopup model dispatch) "Use Splitwire when you want to split the \
+                                                                                             bits of a bus into multiple sets."                                                                          
                         catTip1 "Bus Select" (fun _ -> createBusSelectPopup model dispatch) "Bus Select output connects to one or \
                                                                                                 more selected bits of its input"
                         catTip1 "Bus Compare" (fun _ -> createBusComparePopup model dispatch) "Bus compare outputs 1 if the input bus \

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -238,6 +238,27 @@ let private createGateNPopup (gateType: GateComponentType) (model: Model) dispat
             intIn < 2 || intIn > Constants.maxGateInputs
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
+let private createMergeNPopup (model: Model) dispatch =
+    let title = $"Add N input merge"
+    let beforeInt =
+        fun _ -> str "How many inputs should the merge component have?"
+    let numInputsDefault = 2
+    let intDefault = 1
+    let body = dialogPopupBodyNInts beforeInt numInputsDefault intDefault dispatch
+    let buttonText = "Add"
+    let buttonAction =
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
+            let inputInt = getInt dialogData 
+            let inputList = getIntList dialogData numInputsDefault intDefault
+            createCompStdLabel (MergeN (inputInt, inputList)) model dispatch
+            dispatch ClosePopup
+    let isDisabled =
+        fun (model': Model) ->
+            let intIn = getInt model'.PopupDialogData
+            intIn < 2
+    dialogPopup title body buttonText buttonAction isDisabled [] dispatch
+
 let private createNbitsAdderPopup (model:Model) dispatch =
     let title = sprintf "Add N bits adder"
     let beforeInt =
@@ -859,19 +880,23 @@ let viewCatalogue model dispatch =
                           catTip1 "Not Connected" (fun _ -> createComponent (NotConnected) "" model dispatch) "Not connected component to terminate unused output."]                          
                     makeMenuGroup
                         "Buses"
-                        [ catTip1 "MergeWires"  (fun _ -> createComponent MergeWires "" model dispatch) "Use Mergewires when you want to \
+                        [ 
+                        catTip1 "MergeWires"  (fun _ -> createComponent MergeWires "" model dispatch) "Use Mergewires when you want to \
                                                                                        join the bits of a two busses to make a wider bus. \
                                                                                        Default has LS bits connected to top arm. Use Edit -> Flip Vertically \
                                                                                        after placing component to change this."
-                          catTip1 "SplitWire" (fun _ -> createSplitWirePopup model dispatch) "Use Splitwire when you want to split the \
+                            
+                        catTip1 "MergeN"  (fun _ -> createMergeNPopup model dispatch) "Use Mergewires when you want to \
+                                                                                       join the bits of N busses to make a wider bus."
+                        catTip1 "SplitWire" (fun _ -> createSplitWirePopup model dispatch) "Use Splitwire when you want to split the \
                                                                                              bits of a bus into two sets. \
                                                                                              Default has LS bits connected to top arm. Use Edit -> Flip Vertically \
                                                                                              after placing component to change this."
-                          catTip1 "Bus Select" (fun _ -> createBusSelectPopup model dispatch) "Bus Select output connects to one or \
+                        catTip1 "Bus Select" (fun _ -> createBusSelectPopup model dispatch) "Bus Select output connects to one or \
                                                                                                 more selected bits of its input"
-                          catTip1 "Bus Compare" (fun _ -> createBusComparePopup model dispatch) "Bus compare outputs 1 if the input bus \
+                        catTip1 "Bus Compare" (fun _ -> createBusComparePopup model dispatch) "Bus compare outputs 1 if the input bus \
                                                                                                  matches a constant value as written in decimal, hex, or binary." 
-                          catTip1 "N bits spreader" (fun _ -> createNbitSpreaderPopup model dispatch) "1-to-N bits spreader"]
+                        catTip1 "N bits spreader" (fun _ -> createNbitSpreaderPopup model dispatch) "1-to-N bits spreader"]
                     makeMenuGroup
                         "Gates"
                         [ catTip1 "Not"  (fun _ -> createCompStdLabel Not model dispatch) "Invertor: output is negation of input"

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -242,6 +242,26 @@ let private createMergeNPopup (model: Model) dispatch =
     let title = $"Add N input merge"
     let beforeInt =
         fun _ -> str "How many inputs should the merge component have?"
+    let intDefault = 2
+    let body = dialogPopupBodyOnlyInt beforeInt intDefault dispatch
+    let buttonText = "Add"
+    let buttonAction =
+        fun (model': Model) ->
+            let dialogData = model'.PopupDialogData
+            let inputInt = getInt dialogData
+            createCompStdLabel (MergeN inputInt) model dispatch
+            dispatch ClosePopup
+    let isDisabled =
+        fun (model': Model) ->
+            let intIn = getInt model'.PopupDialogData
+            intIn < 2
+    dialogPopup title body buttonText buttonAction isDisabled [] dispatch
+
+(*
+let private createSplitNPopup (model: Model) dispatch =
+    let title = $"Add N input merge"
+    let beforeInt =
+        fun _ -> str "How many inputs should the merge component have?"
     let numInputsDefault = 2
     let intDefault = 1
     let body = dialogPopupBodyNInts beforeInt numInputsDefault intDefault dispatch
@@ -258,6 +278,7 @@ let private createMergeNPopup (model: Model) dispatch =
             let intIn = getInt model'.PopupDialogData
             intIn < 2
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
+*)
 
 let private createNbitsAdderPopup (model:Model) dispatch =
     let title = sprintf "Add N bits adder"

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -105,6 +105,7 @@ let init() = {
         VerilogErrors = []
         BadLabel = false
         IntList = None
+        IntList2 = None
     }
     Notifications = {
         FromDiagram = None

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -104,6 +104,7 @@ let init() = {
         VerilogCode = None
         VerilogErrors = []
         BadLabel = false
+        IntList = None
     }
     Notifications = {
         FromDiagram = None

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -93,6 +93,17 @@ let private intFormField name (width:string) defaultValue minValue onChange =
         ]
     ]
 
+let private intFormFieldInline name (width: string) defaultValue minValue onChange =
+    Field.div [Field.Props[Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.Center]]] [
+        Label.label [Label.Props [Style [Flex "0 0 auto"; MarginRight "8px"]]] [str name] // Label with flex properties and margin
+        Input.number [
+            Input.Props [Style [Width width;]; Min minValue] // Input with flex property
+            Input.DefaultValue <| sprintf "%d" defaultValue
+            Input.OnChange (getIntEventValue >> onChange)
+        ]
+        hr []
+    ]
+
 let private floatFormField name (width:string) defaultValue minValue onChange =
     Field.div [] [
         Label.label [] [ str name ]
@@ -590,15 +601,15 @@ let private changeMergeN model (comp:Component) dispatch =
         )
         widths
         |> List.mapi (fun index defaultValue ->
-            let portTitle = sprintf "Input Port %d Width :" (index + 1)
-            intFormField portTitle "60px" defaultValue 1 (
+            let portTitle = sprintf "Input Port %d Width :" index
+            intFormFieldInline portTitle "60px" defaultValue 1 (
                 fun newWidth -> 
                     widths
                     |> List.mapi (fun i x -> if i = index then newWidth else x)
                     |> model.Sheet.ChangeMergeN sheetDispatch (ComponentId comp.Id) nInp
             )
         )
-        |> div [] 
+        |> div [Style [MarginBottom "20px"]] 
     ]
 
 /// Used for Input1 Component types. Make field for users to enter a default value for

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -558,9 +558,41 @@ let private makeNumberOfInputsField model (comp:Component) dispatch =
                     dispatch <| SetPopupDialogInt (Some newInpNum)
         )
     ]
-    
 
 let private changeMergeN model (comp:Component) dispatch =
+    let sheetDispatch sMsg = dispatch (Sheet sMsg)
+    
+    let errText =
+        model.PopupDialogData.Int
+        |> Option.map (fun i ->
+            if i < 2 then
+                sprintf "Must have more than 2 inputs"
+            else
+                "")
+        |> Option.defaultValue ""
+
+    let title, nInp =
+        match comp.Type with
+        | MergeN n -> "Number of inputs", n
+        | c -> failwithf "makeNumberOfInputsField called with invalid component: %A" c
+
+    div [] [
+        span
+            [Style [Color Red]]
+            [str errText]
+
+        intFormField title "60px" nInp 2 (
+            fun newInpNum ->
+                if newInpNum >= 2 then
+                    model.Sheet.ChangeMergeN sheetDispatch (ComponentId comp.Id) newInpNum
+                    dispatch <| SetPopupDialogInt (Some newInpNum)
+                else
+                    dispatch <| SetPopupDialogInt (Some newInpNum)
+        )
+    ]
+
+(*
+let private changeSplitN model (comp:Component) dispatch =
     let sheetDispatch sMsg = dispatch (Sheet sMsg)
     
     let errText =
@@ -611,6 +643,7 @@ let private changeMergeN model (comp:Component) dispatch =
         )
         |> div [Style [MarginBottom "20px"]] 
     ]
+*)
 
 /// Used for Input1 Component types. Make field for users to enter a default value for
 /// Input1 Components when they are undriven.

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -752,6 +752,8 @@ let private makeDescription (comp:Component) model dispatch =
     | Demux8 -> div [] [ str "Demultiplexer with one input and eight outputs." ]
     | MergeWires -> div [] [ str "Merge two wires of width n and m into a single wire of width n+m. \
                                   The bit numbers of the whole and each branch are shown when the component is connected." ]
+    | MergeN _ -> div [] [ str "Merge n wires of various widths into a single wire. \
+                                  The bit numbers of the whole and each branch are shown when the component is connected." ]
     | SplitWire _ -> div [] [ str "Split a wire of width n+m into two wires of width n and m. \
                                    The bit numbers of the whole and each branch are shown when the component is connected."]
     | NbitsAdder numberOfBits 

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -408,6 +408,11 @@ let update (msg : Msg) oldModel =
                      | FirstInt -> set int_ (Option.map int32 n)
                      | SecondInt -> set int2_ n)
         |> withNoMsg
+    
+    | SetPopupDialogIntList intlist->
+        model
+        |> set (popupDialogData_ >-> intlist_) intlist
+        |> withNoMsg
 
     | SetPopupDialogMemorySetup m ->
         model

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -414,6 +414,11 @@ let update (msg : Msg) oldModel =
         |> set (popupDialogData_ >-> intlist_) intlist
         |> withNoMsg
 
+    | SetPopupDialogIntList2 intlist2->
+        model
+        |> set (popupDialogData_ >-> intlist2_) intlist2
+        |> withNoMsg
+
     | SetPopupDialogMemorySetup m ->
         model
         |> set (popupDialogData_ >-> memorySetup_) m

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -140,6 +140,7 @@ let shortDisplayMsg (msg:Msg) =
     | SetPopupDialogInt2 _ 
     | SetPopupDialogTwoInts _ 
     | SetPopupDialogIntList _
+    | SetPopupDialogIntList2 _
     | SetPropertiesExtraDialogText _ 
     | SetPopupDialogBadLabel _ 
     | SetPopupDialogMemorySetup _  

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -139,6 +139,7 @@ let shortDisplayMsg (msg:Msg) =
     | SetPopupDialogInt _ 
     | SetPopupDialogInt2 _ 
     | SetPopupDialogTwoInts _ 
+    | SetPopupDialogIntList _
     | SetPropertiesExtraDialogText _ 
     | SetPopupDialogBadLabel _ 
     | SetPopupDialogMemorySetup _  

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -362,8 +362,8 @@ let getCompDetails fs wave =
         | ROM1 mem -> $"ROM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) synchronous read", false
         | RAM1 mem -> $"RAM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) synchronous read", false
         | AsyncRAM1 mem -> $"RAM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) asynchronous read", false             
-        | BusSelection _ | MergeWires | MergeN _ | SplitWire _ ->
-            failwithf "Bus select, MergeWires, MergeN, SplitWire should not appear"
+        | BusSelection _ | MergeWires | MergeN _ | SplitWire _ | SplitN _ ->
+            failwithf "Bus select, MergeWires, MergeN, SplitWire, SplitN should not appear"
         | Input _ | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
             failwithf "Legacy component types should not appear"
         | Shift _ ->
@@ -390,7 +390,7 @@ let getCompGroup fs wave =
         FFRegister
     | AsyncROM1 _ | ROM1 _ | RAM1 _ | AsyncRAM1 _ ->
         Memories                
-    | BusSelection _ | MergeWires | MergeN _ | SplitWire _ ->
+    | BusSelection _ | MergeWires | MergeN _ | SplitWire _ | SplitN _ ->
         failwithf "Bus select, MergeWires, MergeN, SplitWire should not appear"
     | Input _ | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
         failwithf "Legacy component types should not appear"

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -362,8 +362,8 @@ let getCompDetails fs wave =
         | ROM1 mem -> $"ROM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) synchronous read", false
         | RAM1 mem -> $"RAM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) synchronous read", false
         | AsyncRAM1 mem -> $"RAM  ({1 <<< mem.AddressWidth} word X {mem.WordWidth} bit) asynchronous read", false             
-        | BusSelection _ | MergeWires | SplitWire _ ->
-            failwithf "Bus select, MergeWires, SplitWire should not appear"
+        | BusSelection _ | MergeWires | MergeN _ | SplitWire _ ->
+            failwithf "Bus select, MergeWires, MergeN, SplitWire should not appear"
         | Input _ | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
             failwithf "Legacy component types should not appear"
         | Shift _ ->
@@ -390,8 +390,8 @@ let getCompGroup fs wave =
         FFRegister
     | AsyncROM1 _ | ROM1 _ | RAM1 _ | AsyncRAM1 _ ->
         Memories                
-    | BusSelection _ | MergeWires | SplitWire _ ->
-        failwithf "Bus select, MergeWires, SplitWire should not appear"
+    | BusSelection _ | MergeWires | MergeN _ | SplitWire _ ->
+        failwithf "Bus select, MergeWires, MergeN, SplitWire should not appear"
     | Input _ | Constant _ | AsyncROM _ | ROM _ | RAM _ ->
         failwithf "Legacy component types should not appear"
     | Shift _ ->

--- a/src/Renderer/UI/WaveSim/WaveSimSelect.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimSelect.fs
@@ -106,6 +106,7 @@ let getInputPortName (compType: ComponentType) (port: InputPortNumber) : string 
     | Input _ -> failwithf "Legacy Input component types should never occur"
     | IOLabel -> failwithf "IOLabel should not occur in getInputPortName"
     | MergeWires -> failwithf "MergeWires should not occur in getInputPortName"
+    | MergeN _ -> failwithf "MergeN should not occur in getInputPortName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getInputPortName"
     | BusSelection _ -> failwithf "BusSelection should not occur in getInputPortName"
 
@@ -137,6 +138,7 @@ let getInputName (withComp: bool) (comp: FastComponent) (port: InputPortNumber) 
         | NotConnected -> failwithf "NotConnected should not occur in getInputName"
         | IOLabel -> failwithf "IOLabel should not occur in getInputName"
         | MergeWires -> failwithf "MergeWires should not occur in getInputName"
+        | MergeN _ -> failwithf "MergeN should not occur in getInputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getInputName"
         | BusSelection _ -> failwithf "BusSeleciton should not occur in getInputName"
 
@@ -174,6 +176,7 @@ let getOutputPortName (compType: ComponentType) (port: OutputPortNumber) : strin
     | ROM _ | RAM _ | AsyncROM _ -> failwithf "What? Legacy RAM component types should never occur"
     | Input _ -> failwithf "Legacy Input component types should never occur"
     | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
+    | MergeN _ -> failwithf "MergeN should not occur in getOutputName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
     | BusSelection _ -> failwithf "BusSeleciton should not occur in getOutputName"
 
@@ -215,6 +218,7 @@ let getOutputName (withComp: bool) (comp: FastComponent) (port: OutputPortNumber
         | Input _ -> failwithf "Legacy Input component types should never occur"
         | NotConnected -> failwithf "NotConnected should not occur in getOutputName"
         | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
+        | MergeN _ -> failwithf "MergeN should not occur in getOutputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
         | BusSelection _ -> failwithf "BusSelection should not occur in getOutputName"
 

--- a/src/Renderer/UI/WaveSim/WaveSimSelect.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimSelect.fs
@@ -108,6 +108,7 @@ let getInputPortName (compType: ComponentType) (port: InputPortNumber) : string 
     | MergeWires -> failwithf "MergeWires should not occur in getInputPortName"
     | MergeN _ -> failwithf "MergeN should not occur in getInputPortName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getInputPortName"
+    | SplitN _ -> failwithf "SplitN should not occur in getInputPortName"
     | BusSelection _ -> failwithf "BusSelection should not occur in getInputPortName"
 
 /// Get names for waves that are from Input ports
@@ -140,6 +141,7 @@ let getInputName (withComp: bool) (comp: FastComponent) (port: InputPortNumber) 
         | MergeWires -> failwithf "MergeWires should not occur in getInputName"
         | MergeN _ -> failwithf "MergeN should not occur in getInputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getInputName"
+        | SplitN _ -> failwithf "SplitN should not occur in getInputName"
         | BusSelection _ -> failwithf "BusSeleciton should not occur in getInputName"
 
     if withComp then 
@@ -178,6 +180,7 @@ let getOutputPortName (compType: ComponentType) (port: OutputPortNumber) : strin
     | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
     | MergeN _ -> failwithf "MergeN should not occur in getOutputName"
     | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
+    | SplitN _ -> failwithf "SplitN should not occur in getOutputName"
     | BusSelection _ -> failwithf "BusSeleciton should not occur in getOutputName"
 
 /// Get names for waves that are from Output ports
@@ -220,6 +223,7 @@ let getOutputName (withComp: bool) (comp: FastComponent) (port: OutputPortNumber
         | MergeWires -> failwithf "MergeWires should not occur in getOutputName"
         | MergeN _ -> failwithf "MergeN should not occur in getOutputName"
         | SplitWire _ -> failwithf "SplitWire should not occur in getOutputName"
+        | SplitN _ -> failwithf "SplitN should not occur in getOutputName"
         | BusSelection _ -> failwithf "BusSelection should not occur in getOutputName"
 
     if withComp then 


### PR DESCRIPTION
 - N-way split acts like n-way bus select
 - To do: add split and merge fastreduce for bigint after bug in mergewires and splitwires is fixed. fix labelling of rotated components