### PR TITLE
Update BusWireUpdateHelpers.fs - Correction to prevent modern wire circles appearing in the wrong place

### DIFF
--- a/src/Renderer/DrawBlock/BusWireUpdateHelpers.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdateHelpers.fs
@@ -705,7 +705,7 @@ let updateCirclesOnNet
             hsL 
             |> List.tryPick (fun hs -> 
                 if close hs.P join.Q && (close hs.Qmin join.P || close hs.Qmax join.P) then
-                    Some [hs.Qmin, hs.Index, hs.OfWire]
+                    Some [join.P, hs.Index, hs.OfWire]
                 else 
                     None)
             |> Option.defaultValue [])


### PR DESCRIPTION
Issue #348 fix

The value assigned is incorrect in the vJoinCircles function - if you look at hJoinCircles it is correct, so it is just a matter of changing the value to correct the issue