### PR TITLE
Fix demo projects not found in macOS build issue

### DIFF
--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -42,10 +42,10 @@ let staticDir() =
     /// on MacOs we think it should be ../Resources/static
     /// we hope staticDir will give this?
     let isMac = Node.Api.``process``.platform = Node.Base.Darwin
-    if productionBuild  && not isMac then
+    if productionBuild && not isMac then
         "./resources/static"
     elif productionBuild && isMac then
-        "./Resources/static"
+        path.join [|__dirname; ".."; ".."; "static"|]
     else
         staticDirFromStatic()
 

--- a/src/Renderer/UI/TopMenuView.fs
+++ b/src/Renderer/UI/TopMenuView.fs
@@ -351,11 +351,14 @@ let private openProject model dispatch =
 /// load demo project into Issie executables
 let loadDemoProject model dispatch basename =
     warnAppWidth dispatch (fun _ ->
-        let newDir = "./demos/" + basename
+        let isMac = Node.Api.``process``.platform = Node.Base.Darwin
+        let homeDir = if isMac then pathJoin [|FilesIO.staticDir(); ".."; ".."|] else "."
+
+        let newDir = homeDir + "/demos/" + basename
         let sourceDir = FilesIO.staticDir() + "/demos/" + basename
         printf "%s" $"loading demo {sourceDir} into {newDir}"
 
-        ensureDirectory "./demos/"
+        ensureDirectory (homeDir + "/demos/")
         ensureDirectory newDir
 
         readFilesFromDirectory newDir


### PR DESCRIPTION
### Issue

#432 

### Problem

MacOS resolves `.` path to root instead of app location, which resulted in:
* `./Resources/static` directory not found; and
* `ensureDirectory "./demos/"` fail as it attempts to write in root.

### Fix

* Updated `FileIO.staticDir` to point to correct directory using `__dirname`.
* Updated `loadDemoProject` to create copy in app location.
