### PR TITLE
delete Pending list when not needed - mends longstanding bug

### DIFF
--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -839,7 +839,7 @@ let executePendingMessagesF n model =
         | None -> failwithf "shouldn't happen"
         | Some mMsg -> 
             match mMsg with
-            | Sheet sMsg -> sheetMsg sMsg model
+            | Sheet sMsg -> sheetMsg sMsg {model with Pending = []}
             | _ -> failwithf "shouldn't happen "
         
     //ignore the exectue message


### PR DESCRIPTION
The theory is that  the Pending list gets very long and after a while can crash Issie! Pruning it when possible seems to make a big difference, and is the right thing to do even if it does not cure the space-leak crashes.