### PR TITLE
Waveform Simulator Improvement

### DIFF
--- a/src/Renderer/Common/CommonTypes.fs
+++ b/src/Renderer/Common/CommonTypes.fs
@@ -879,8 +879,6 @@ module CommonTypes
         Radix: NumberBase option
         /// Width of the waveform column
         WaveformColumnWidth: float option
-        /// Number of visible cycles in the waveform column
-        ShownCycles: int option
         /// RAMs which are selected to be shown in the RAM tables
         SelectedRams: Map<ComponentId, string> option
         SelectedFRams: Map<FComponentId, string> option

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -250,6 +250,14 @@ type WaveSimModel = {
     /// The value of SelectedWaves when the user started dragging a label.
     /// Used to restore SelectedWaves if the user drops a label in an illegal location.
     PrevSelectedWaves: WaveIndexT list option
+
+    // Scrollbar properties:
+    /// <summary>Scrollbar SVG element to be rendered.</summary>
+    ScrollbarSvg: ReactElement option
+    /// <summary>Number of cycles scrollbar currently represents, defaults to 100.</summary>
+    ScrollbarRep: int
+    /// <summary>Width, in pixels, to render scrollbar at.</summary>
+    ScrollbarWidth: float
 }
 
 

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -159,13 +159,11 @@ type WaveSimState =
     /// if waveSim has been explicitly ended
     | Ended
 
-/// <summary>Type used to describe the position of the mouse relative
-/// to the thumb on the scrollbar, which affect the modes of scrolling:
-/// normal or "catching up".</summary>
-type ScrollbarMousePos =
-    | Tb
-    | TbBufferLeft
-    | TbBufferRight
+/// <summary>Describe WaveSim's scrollbar's mouse actions' type of operation.</summary>
+type ScrollbarMouseAction =
+    | StartScrollbarDrag
+    | InScrollbarDrag
+    | ClearScrollbarDrag
 
 /// Identifies which Component and Port drives a waveform.
 /// Must be an Output port (Input ports cannot drive waveforms).
@@ -264,12 +262,13 @@ type WaveSimModel = {
     ScrollbarTbWidth: float
     /// <summary>Starting position of scrollbar's thumb, in pixels.</summary>
     ScrollbarTbPos: float
+    /// <summary>Offset between scrollbar's thumb's position and cursor's position.
+    /// If is Some float, scrollbar is in drag mode; otherwise scrollbar is NOT in drag.</summary>
+    ScrollbarTbOffset: float option
     /// <summary>Width of scrollbar's gray background, in pixels.</summary>
     ScrollbarBkgWidth: float
     /// <summary>Number of clock cycles scrollbar's background represents.</summary>
     ScrollbarBkgRepCycs: int
-    /// <summary>Remaining incomplete cycles for thumb to move in orderto keep up with cursor.</summary>
-    ScrollbarCounter: float
 }
 
 
@@ -450,7 +449,7 @@ type Msg =
     | SendSeqMsgAsynch of seq<Msg>
     | ContextMenuAction of e: Browser.Types.MouseEvent
     | ContextMenuItemClick of menuType:string * item:string * dispatch: (Msg -> unit)
-    | ScrollbarMouseMsg of mov:XYPos * area:ScrollbarMousePos * dispatch:(Msg->unit)
+    | ScrollbarMouseMsg of cursor:float * action:ScrollbarMouseAction * dispatch:(Msg->unit)
 
 
 //================================//

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -159,6 +159,14 @@ type WaveSimState =
     /// if waveSim has been explicitly ended
     | Ended
 
+/// <summary>Type used to describe the position of the mouse relative
+/// to the thumb on the scrollbar, which affect the modes of scrolling:
+/// normal or "catching up".</summary>
+type ScrollbarMousePos =
+    | Tb
+    | TbBufferLeft
+    | TbBufferRight
+
 /// Identifies which Component and Port drives a waveform.
 /// Must be an Output port (Input ports cannot drive waveforms).
 type DriverT = {
@@ -252,12 +260,16 @@ type WaveSimModel = {
     PrevSelectedWaves: WaveIndexT list option
 
     // Scrollbar properties:
-    /// <summary>Scrollbar SVG element to be rendered.</summary>
-    ScrollbarSvg: ReactElement option
-    /// <summary>Number of cycles scrollbar currently represents, defaults to 100.</summary>
-    ScrollbarRep: int
-    /// <summary>Width, in pixels, to render scrollbar at.</summary>
-    ScrollbarWidth: float
+    /// <summary>Width of scrollbar's thumb, in pixels.</summary>
+    ScrollbarTbWidth: float
+    /// <summary>Starting position of scrollbar's thumb, in pixels.</summary>
+    ScrollbarTbPos: float
+    /// <summary>Width of scrollbar's gray background, in pixels.</summary>
+    ScrollbarBkgWidth: float
+    /// <summary>Number of clock cycles scrollbar's background represents.</summary>
+    ScrollbarBkgRepCycs: int
+    /// <summary>Remaining incomplete cycles for thumb to move in orderto keep up with cursor.</summary>
+    ScrollbarCounter: float
 }
 
 
@@ -438,6 +450,7 @@ type Msg =
     | SendSeqMsgAsynch of seq<Msg>
     | ContextMenuAction of e: Browser.Types.MouseEvent
     | ContextMenuItemClick of menuType:string * item:string * dispatch: (Msg -> unit)
+    | ScrollbarMouseMsg of mov:XYPos * area:ScrollbarMousePos * dispatch:(Msg->unit)
 
 
 //================================//

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -164,6 +164,7 @@ type ScrollbarMouseAction =
     | StartScrollbarDrag
     | InScrollbarDrag
     | ClearScrollbarDrag
+    | ReleaseScrollQueue
 
 /// Identifies which Component and Port drives a waveform.
 /// Must be an Output port (Input ports cannot drive waveforms).
@@ -269,6 +270,10 @@ type WaveSimModel = {
     ScrollbarBkgWidth: float
     /// <summary>Number of clock cycles scrollbar's background represents.</summary>
     ScrollbarBkgRepCycs: int
+    /// <summary>Counter used to coalesce scrollbar mouse actions together.
+    /// If true, queue is clear and can dispatch scrollbar update.
+    /// Otherwise, an update is in progress and mouse event should not be pushed onto the queue.</summary>
+    ScrollbarQueueIsEmpty: bool
 }
 
 

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -342,6 +342,20 @@ let displayView model dispatch =
     let conns = BusWire.extractConnections model.Sheet.Wire
     let comps = SymbolUpdate.extractComponents model.Sheet.Wire.Symbol
     let canvasState = comps,conns   
+
+    // mouse ops for wavesim scrollbar
+    let wavesimSbMouseMoveHandler (event: Browser.Types.MouseEvent): unit = // if in drag, update scrollbar; otherwise do nothing
+        let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
+        if Option.isSome wsm.ScrollbarTbOffset
+        then ScrollbarMouseMsg (event.screenX, InScrollbarDrag, dispatch) |> dispatch
+        else ()
+
+    let wavesimSbMouseUpHandler (event: Browser.Types.MouseEvent): unit = // if in drag clear drag; otherwise do nothing
+        let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
+        if Option.isSome wsm.ScrollbarTbOffset
+        then ScrollbarMouseMsg (event.screenX, ClearScrollbarDrag, dispatch) |> dispatch
+        else ()
+
     match model.Spinner with
     | Some fn -> 
         dispatch <| UpdateModel fn
@@ -387,7 +401,7 @@ let displayView model dispatch =
             //--------------------------------------------------------------------------------------//
             //---------------------------------right section----------------------------------------//
             // right section has horizontal divider bar and tabs
-            div [ HTMLAttr.Id "RightSection"; rightSectionStyle model ]
+            div [ HTMLAttr.Id "RightSection"; rightSectionStyle model; OnMouseMove wavesimSbMouseMoveHandler; OnMouseUp wavesimSbMouseUpHandler ]
                   // vertical and draggable divider bar
                 [ dividerbar model dispatch
                   // tabs for different functions

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -347,13 +347,13 @@ let displayView model dispatch =
     let wavesimSbMouseMoveHandler (event: Browser.Types.MouseEvent): unit = // if in drag, update scrollbar; otherwise do nothing
         let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
         if Option.isSome wsm.ScrollbarTbOffset
-        then ScrollbarMouseMsg (event.screenX, InScrollbarDrag, dispatch) |> dispatch
+        then ScrollbarMouseMsg (event.clientX, InScrollbarDrag, dispatch) |> dispatch
         else ()
 
     let wavesimSbMouseUpHandler (event: Browser.Types.MouseEvent): unit = // if in drag clear drag; otherwise do nothing
         let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
         if Option.isSome wsm.ScrollbarTbOffset
-        then ScrollbarMouseMsg (event.screenX, ClearScrollbarDrag, dispatch) |> dispatch
+        then ScrollbarMouseMsg (event.clientX, ClearScrollbarDrag, dispatch) |> dispatch
         else ()
 
     match model.Spinner with

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -46,6 +46,9 @@ let initWSModel  : WaveSimModel = {
     HoveredLabel = None
     DraggedIndex = None
     PrevSelectedWaves = None
+    ScrollbarSvg = None
+    ScrollbarRep = 100 // default value
+    ScrollbarWidth = 0.0 // placeholder only
 }
 
 /// This is needed because DrawBlock cannot directly access Issie Model.

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -49,9 +49,9 @@ let initWSModel  : WaveSimModel = {
     
     ScrollbarTbWidth = 0.0 // overwritten when first rendered
     ScrollbarTbPos = 0.0 // overwritten when first rendered
+    ScrollbarTbOffset = None // default value: not in scroll
     ScrollbarBkgWidth = 0.0 // overwritten when first rendered
     ScrollbarBkgRepCycs = 100 // default value
-    ScrollbarCounter = 0.0 // default value
 }
 
 /// This is needed because DrawBlock cannot directly access Issie Model.

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -135,7 +135,6 @@ let getSavedWaveInfo (wsModel: WaveSimModel) : SavedWaveInfo =
         SelectedWaves = Some wsModel.SelectedWaves
         Radix = Some wsModel.Radix
         WaveformColumnWidth = Some wsModel.WaveformColumnWidth
-        ShownCycles = Some wsModel.ShownCycles
         SelectedFRams = Some wsModel.SelectedRams
         SelectedRams = None
 
@@ -156,7 +155,6 @@ let loadWSModelFromSavedWaveInfo (swInfo: SavedWaveInfo) : WaveSimModel =
             SelectedWaves = Option.defaultValue initWSModel.SelectedWaves swInfo.SelectedWaves
             Radix = Option.defaultValue initWSModel.Radix swInfo.Radix
             WaveformColumnWidth = Option.defaultValue initWSModel.WaveformColumnWidth swInfo.WaveformColumnWidth
-            ShownCycles = Option.defaultValue initWSModel.ShownCycles swInfo.ShownCycles
             SelectedRams = Option.defaultValue initWSModel.SelectedRams swInfo.SelectedFRams
     }
 

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -9,7 +9,7 @@ open Optics.Operators
 
 module Constants =
     /// TODO: Remove this limit, after making simulation interruptable This stops the waveform simulator moving past 1000 clock cycles.
-    let maxLastClk = 1000
+    let maxLastClk = 2000
     /// Needed to prevent possible overrun of simulation arrays
     let maxStepsOverflow = 3
 

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -52,6 +52,7 @@ let initWSModel  : WaveSimModel = {
     ScrollbarTbOffset = None // default value: not in scroll
     ScrollbarBkgWidth = 0.0 // overwritten when first rendered
     ScrollbarBkgRepCycs = 100 // default value
+    ScrollbarQueueIsEmpty = true // default value: empty scroll queue
 }
 
 /// This is needed because DrawBlock cannot directly access Issie Model.

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -46,9 +46,12 @@ let initWSModel  : WaveSimModel = {
     HoveredLabel = None
     DraggedIndex = None
     PrevSelectedWaves = None
-    ScrollbarSvg = None
-    ScrollbarRep = 100 // default value
-    ScrollbarWidth = 0.0 // placeholder only
+    
+    ScrollbarTbWidth = 0.0 // overwritten when first rendered
+    ScrollbarTbPos = 0.0 // overwritten when first rendered
+    ScrollbarBkgWidth = 0.0 // overwritten when first rendered
+    ScrollbarBkgRepCycs = 100 // default value
+    ScrollbarCounter = 0.0 // default value
 }
 
 /// This is needed because DrawBlock cannot directly access Issie Model.

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -9,7 +9,7 @@ open Optics.Operators
 
 module Constants =
     /// TODO: Remove this limit, after making simulation interruptable This stops the waveform simulator moving past 1000 clock cycles.
-    let maxLastClk = 2000
+    let maxLastClk = 10000
     /// Needed to prevent possible overrun of simulation arrays
     let maxStepsOverflow = 3
 

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -579,6 +579,15 @@ let update (msg : Msg) oldModel =
     | TruthTableMsg ttMsg ->
         TruthTableUpdate.truthTableUpdate model ttMsg
 
+    | ScrollbarMouseMsg (mov, pos, dispatch) ->
+        if (mov.X = 0) || (Option.isNone model.WaveSimSheet) // catch no-ops here to decrease load
+        then 
+            model, Cmd.none
+        else
+            let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
+            WaveSim.updateScrolBar wsm dispatch mov.X posl
+            model, Cmd.none
+
     // Various messages here that are not implemented as yet, or are no longer used
     // should be sorted out
     | LockTabsToWaveSim | UnlockTabsFromWaveSim | SetExitDialog _ 

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -579,14 +579,10 @@ let update (msg : Msg) oldModel =
     | TruthTableMsg ttMsg ->
         TruthTableUpdate.truthTableUpdate model ttMsg
 
-    | ScrollbarMouseMsg (mov, pos, dispatch) ->
-        if (mov.X = 0) || (Option.isNone model.WaveSimSheet) // catch no-ops here to decrease load
-        then 
-            model, Cmd.none
-        else
-            let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
-            WaveSim.updateScrollbar wsm dispatch mov.X pos
-            model, Cmd.none
+    | ScrollbarMouseMsg (cursor: float, action: ScrollbarMouseAction, dispatch: Msg->unit) ->
+        let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
+        WaveSim.updateScrollbar wsm dispatch cursor action
+        model, Cmd.none
 
     // Various messages here that are not implemented as yet, or are no longer used
     // should be sorted out

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -585,7 +585,7 @@ let update (msg : Msg) oldModel =
             model, Cmd.none
         else
             let wsm = Map.find (Option.get model.WaveSimSheet) model.WaveSim
-            WaveSim.updateScrolBar wsm dispatch mov.X posl
+            WaveSim.updateScrollbar wsm dispatch mov.X pos
             model, Cmd.none
 
     // Various messages here that are not implemented as yet, or are no longer used

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -117,6 +117,7 @@ let shortDisplayMsg (msg:Msg) =
         | SetPopupNewConstraint _ 
         | SetPopupAlgebraInputs _ 
         | SetPopupAlgebraError _ -> None
+    | ScrollbarMouseMsg _
 
     | ChangeRightTab _ -> None
     | ChangeSimSubTab _ -> None

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -996,7 +996,7 @@ let makeScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit): ReactElement =
 
     div [Style[ MarginTop "16px"; MarginBottom "16px"; Height "30px"]] [
         button [ Button.Props [clkCycleLeftStyle] ]
-            (fun _ -> scrollWaveformsBy (-wsm.ShownCycles+1))
+            (fun _ -> scrollWaveformsBy (-wsm.ShownCycles))
             (str "◀")
         svg
             [Style [Width $"{bkgWidth}"; Height $"{WaveSimStyle.Constants.scrollbarHeight}px"];]
@@ -1007,7 +1007,7 @@ let makeScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit): ReactElement =
                 rect (tbBufferRightPropList wsm.ScrollbarTbPos wsm.ScrollbarTbWidth) []; // right buffer
             ]
         button [ Button.Props [scrollbarClkCycleRightStyle]]
-            (fun _ -> scrollWaveformsBy (wsm.ShownCycles-1))
+            (fun _ -> scrollWaveformsBy (wsm.ShownCycles))
             (str "▶")
     ]
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -311,7 +311,15 @@ let setScrollbarTbByCycs (wsm: WaveSimModel) (dispatch: Msg->unit) (moveByCycs: 
     let maxSimCyc = Constants.maxLastClk
 
     let newStartCyc = (wsm.StartCycle+moveWindowBy) |> bound minSimCyc (maxSimCyc-wsm.ShownCycles+1)
-    let newCurrCyc = if moveWindowBy > 0 then (newStartCyc+wsm.ShownCycles-1) else (newStartCyc)
+    let newCurrCyc =
+        let newEndCyc = newStartCyc+wsm.ShownCycles-1
+        if newStartCyc <= wsm.CurrClkCycle && wsm.CurrClkCycle <= newEndCyc
+        then
+            wsm.CurrClkCycle
+        else
+            if abs (wsm.CurrClkCycle - newStartCyc) < abs (wsm.CurrClkCycle - newEndCyc)
+            then newStartCyc
+            else newEndCyc
 
     GenerateWaveforms {wsm with StartCycle = newStartCyc; CurrClkCycle = newCurrCyc} |> dispatch
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -923,8 +923,10 @@ let makeWaveformsWithTimeOut
 let generateScrollbarInfo (wsm: WaveSimModel): {| tbWidth: float; tbPos: float; bkgRep: int |} =
     let bkgWidth = wsm.ScrollbarBkgWidth - 60. // 60 = 2x width of buttons
 
+    /// <summary>Return target value when within min and max value, otherwise min or max.</summary>
+    let bound (minV: int) (maxV: int) (tarV: int): int = tarV |> max minV |> min maxV
     let currShownMaxCyc = wsm.StartCycle + wsm.ShownCycles
-    let newBkgRep = max (wsm.ScrollbarBkgRepCycs) (currShownMaxCyc)
+    let newBkgRep = [ wsm.ScrollbarBkgRepCycs; currShownMaxCyc; wsm.ShownCycles*2 ] |> List.max |> bound 0 Constants.maxLastClk
 
     let tbCalcWidth = bkgWidth / (1. + (float newBkgRep / float wsm.ShownCycles))
     let tbWidth = max tbCalcWidth WaveSimStyle.Constants.scrollbarThumbMinWidth

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -942,10 +942,7 @@ let generateScrollbarInfo (wsm: WaveSimModel): {| tbWidth: float; tbPos: float; 
     let tbWidth = max tbCalcWidth WaveSimStyle.Constants.scrollbarThumbMinWidth
     
     let tbMoveWidth = bkgWidth - tbWidth
-    let tbPos =
-        if tbWidth > WaveSimStyle.Constants.scrollbarThumbMinWidth
-        then (float wsm.StartCycle) / (float newBkgRep - float wsm.ShownCycles) * tbMoveWidth
-        else (float wsm.CurrClkCycle) / (float newBkgRep-1.) * tbMoveWidth
+    let tbPos = (float wsm.StartCycle) / (float newBkgRep - float wsm.ShownCycles) * tbMoveWidth
 
     // debug statements:
     // printfn "DEBUG:generateScrollbarInfo: Input -"
@@ -953,6 +950,7 @@ let generateScrollbarInfo (wsm: WaveSimModel): {| tbWidth: float; tbPos: float; 
     // printfn "DEBUG:generateScrollbarInfo: wsm.StartCycle = %d cycles" wsm.StartCycle
     // printfn "DEBUG:generateScrollbarInfo: wsm.ShownCycles = %d cycles" wsm.ShownCycles
     // printfn "DEBUG:generateScrollbarInfo: wsm.ScrollbarBkgRepCycs = %d cycles" wsm.ScrollbarBkgRepCycs
+    // printfn "DEBUG:generateScrollbarInfo: bkgWidth = %.1f cycles" bkgWidth
     // printfn "DEBUG:generateScrollbarInfo: Output -"
     // printfn "DEBUG:generateScrollbarInfo: tbWidth = %.1fpx" tbWidth
     // printfn "DEBUG:generateScrollbarInfo: tbPos = %.1fpx" tbPos

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -21,7 +21,7 @@ module Constants =
     /// <summary>Config variable to choose whether to generate the full 1000 cycles of SVG.</summary>
     let generateVisibleOnly = true
     /// <summary>Config variable to choose whether to print performance analysis info to console.</summary>
-    let showPerfLogs = true
+    let showPerfLogs = false
 
 
 /// <summary>Generates SVG to display values on non-binary waveforms when there is enough space.</summary>

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -879,39 +879,43 @@ let makeScrollbarSvg (wsm: WaveSimModel): ReactElement*int =
 
     /// <summary>Function to calculate length and position of scrollbar thumb.</summary>
     let scrollbarDispFunc (currCyc: int) (startCyc: int) (shownCyc: int) (currBkgRep: int) =
-        let currShownMaxCyc = startCyc + shownCyc - 1
+        let currShownMaxCyc = startCyc + shownCyc
         let newBkgRep = max (currBkgRep) (currShownMaxCyc)
     
         let tbMinWidth = WaveSimStyle.Constants.scrollbarThumbMinWidth
-        let tbCalcWidth = (float shownCyc) / (float newBkgRep) * bkgWidth
+        let tbCalcWidth = bkgWidth / (1. + (float newBkgRep / float shownCyc))
         let tbWidth = max tbCalcWidth tbMinWidth
         
-        let tbMoveWidth = bkgWidth - tbWidth + 1.
-        let tbPos = (float startCyc) / (float newBkgRep) * tbMoveWidth
+        let tbMoveWidth = bkgWidth - tbWidth
+        let tbPos =
+            if tbWidth > 5.0 
+            then (float startCyc) / (float newBkgRep - float shownCyc) * tbMoveWidth
+            else (float currCyc) / (float newBkgRep-1.) * tbMoveWidth
     
         {| tbWidth = tbWidth; tbPos = tbPos; bkgRep = newBkgRep |}
 
     let dispInfo = scrollbarDispFunc wsm.CurrClkCycle wsm.StartCycle wsm.ShownCycles wsm.ScrollbarRep
-    // printfn "DEBUG:makeScrollbarSvg: wsm.CurrClkCycle = %A cycles" wsm.CurrClkCycle
-    // printfn "DEBUG:makeScrollbarSvg: wsm.ShownCycles = %A cycles" wsm.ShownCycles
-    // printfn "DEBUG:makeScrollbarSvg: wsm.ScrollbarRep = %A cycles" wsm.ScrollbarRep
-    // printfn "DEBUG:makeScrollbarSvg: newBkgRep = %A cycles" dispInfo.bkgRep
-    // printfn "DEBUG:makeScrollbarSvg: tbPos = %A px" dispInfo.tbPos
-    // printfn "DEBUG:makeScrollbarSvg: tbWidth = %A px" dispInfo.tbWidth
+    // printfn "DEBUG:makeScrollbarSvg: wsm.CurrClkCycle = %d cycles" wsm.CurrClkCycle
+    // printfn "DEBUG:makeScrollbarSvg: wsm.StartCycle = %d cycles" wsm.StartCycle
+    // printfn "DEBUG:makeScrollbarSvg: wsm.ShownCycles = %d cycles" wsm.ShownCycles
+    // printfn "DEBUG:makeScrollbarSvg: wsm.ScrollbarRep = %d cycles" wsm.ScrollbarRep
+    // printfn "DEBUG:makeScrollbarSvg: newBkgRep = %d cycles" dispInfo.bkgRep
+    // printfn "DEBUG:makeScrollbarSvg: tbPos = %.1f px" dispInfo.tbPos
+    // printfn "DEBUG:makeScrollbarSvg: tbWidth = %.1f px" dispInfo.tbWidth
 
     let bkgPropList (width: float): List<IProp> =
         [
             HTMLAttr.Id "scrollbarBkg";
             SVGAttr.X $"0px"; SVGAttr.Y "0.5px";
-            SVGAttr.Width $"{width}px"; SVGAttr.Height $"{WaveSimStyle.Constants.scrollbarHeight-1.0}px";
+            SVGAttr.Width $"%.1f{width}px"; SVGAttr.Height $"%.1f{WaveSimStyle.Constants.scrollbarHeight-1.0}px";
             SVGAttr.Fill "lightgray"; SVGAttr.Stroke "gray"; SVGAttr.StrokeWidth "1px";
         ]
 
     let tbPropList (pos: float) (width: float): List<IProp> =
         [
             HTMLAttr.Id "scrollbarThumb"
-            SVGAttr.X $"{pos}px"; SVGAttr.Y "0.5px";
-            SVGAttr.Width $"{width}px"; SVGAttr.Height $"{WaveSimStyle.Constants.scrollbarHeight-1.0}px";
+            SVGAttr.X $"%.1f{pos}px"; SVGAttr.Y "0.5px";
+            SVGAttr.Width $"%.1f{width}px"; SVGAttr.Height $"%.1f{WaveSimStyle.Constants.scrollbarHeight-1.0}px";
             SVGAttr.Fill "white"; SVGAttr.Stroke "gray"; SVGAttr.StrokeWidth "1px";
         ]
 

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -961,16 +961,16 @@ let makeScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit): ReactElement =
     let bkgWidth = wsm.ScrollbarBkgWidth - 60. // 60 = 2x width of buttons
 
     let tbMouseDownHandler (event: Browser.Types.MouseEvent): unit = // start drag
-        ScrollbarMouseMsg (event.screenX, StartScrollbarDrag, dispatch) |> dispatch
+        ScrollbarMouseMsg (event.clientX, StartScrollbarDrag, dispatch) |> dispatch
 
     let tbMouseMoveHandler (event: Browser.Types.MouseEvent): unit = // if in drag, drag; otherwise do nothing
         if Option.isSome wsm.ScrollbarTbOffset
-        then ScrollbarMouseMsg (event.screenX, InScrollbarDrag, dispatch) |> dispatch
+        then ScrollbarMouseMsg (event.clientX, InScrollbarDrag, dispatch) |> dispatch
         else ()
 
     let tbMouseUpHandler (event: Browser.Types.MouseEvent): unit = // if in drag, clear drag; otherwise do nothing
         if Option.isSome wsm.ScrollbarTbOffset
-        then ScrollbarMouseMsg (event.screenX, ClearScrollbarDrag, dispatch) |> dispatch
+        then ScrollbarMouseMsg (event.clientX, ClearScrollbarDrag, dispatch) |> dispatch
         else ()
 
     let bkgPropList (width: float): List<IProp> =
@@ -1010,8 +1010,9 @@ let makeScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit): ReactElement =
 /// Called in <c>update</c> when <c>ScrollbarMouseMsg</c> is dispatched.</summary>
 /// <param name="wsm">Target <c>WaveSimModel</c>.</param>
 /// <param name="dispatch">Dispatch function to send messages with, not used directly.</param>
-/// <param name="cursor">Cursor postion in relation to the screen, i.e. <c>event.screenX</c>.</param>
+/// <param name="cursor">Cursor postion in relation to the screen, i.e. <c>event.clientX</c>.</param>
 /// <param name="action">Scrollbar action to do, see choices for more info, in type of <c>ScrollbarMouseAction</c>.</param>
+/// <remarks>Note that <c>screenX</c> does NOT scale with web zoom and will cause weird results!</remarks>
 let updateScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit) (cursor: float) (action: ScrollbarMouseAction): unit =
     /// <summary>Translate mouse movements in pixels to number of cycles to move by.
     /// Linear translator aims to allow scrollbar thumb to follow cursor.</summary>

--- a/src/Renderer/UI/WaveSim/WaveSim.fs
+++ b/src/Renderer/UI/WaveSim/WaveSim.fs
@@ -1009,7 +1009,7 @@ let makeScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit): ReactElement =
 /// <param name="dispatch">Dispatch function to send messages with, not used directly.</param>
 /// <param name="dx">Number of pixels the cursor has moved by on the scrollbar thumb.</param>
 /// <param name="pos">Position of cursor when mouse event is fired.</param>
-let updateScrollBar (wsm: WaveSimModel) (dispatch: Msg->unit) (dx: float) (pos: ModelType.ScrollbarMousePos): unit =
+let updateScrollbar (wsm: WaveSimModel) (dispatch: Msg->unit) (dx: float) (pos: ModelType.ScrollbarMousePos): unit =
     /// <summary>Translate mouse movements in pixels to number of cycles to move by.
     /// Linear translator aims to allow scrollbar thumb to follow cursor.</summary>
     /// <param name="dx">Number of pixels mouse has moved in X direction, obtained from MouseMove event.</param>

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -202,8 +202,9 @@ let binaryWavePoints (clkCycleWidth: float) (startCycle: int) (index: int) (tran
     | ZeroToOne | OneToOne ->
         [|topL; topR|]
 
-/// Generate points for a non-binary waveform.
-let nonBinaryWavePoints (clkCycleWidth: float) (startCycle: int) (index: int)  (transition: NonBinaryTransition) : (XYPos array * XYPos array) =
+/// <summary>Generate polyline points for a non-binary waveform via transition info.</summary>
+let nonBinaryWavePoints (clkCycleWidth: float) (startCycle: int) (index: int) (transition: NonBinaryTransition)
+    : array<XYPos>*array<XYPos> =
     let xLeft, _ = makeXCoords clkCycleWidth (startCycle + index) (NonBinaryTransition transition)
     let _, topR, _, botR = makeCoords clkCycleWidth (startCycle + index) (NonBinaryTransition transition)
 
@@ -220,6 +221,23 @@ let nonBinaryWavePoints (clkCycleWidth: float) (startCycle: int) (index: int)  (
             [|crossHatchMid; crossHatchTop; topR|], [|crossHatchMid; crossHatchBot; botR|]
     | Const ->
         [|topR|], [|botR|]
+
+/// <summary>Generate polyfill points for a non-binary gap via gap info.</summary>
+let nonBinaryFillPoints (clkCycleWidth: float) (gap: Gap): array<XYPos> =
+    let xLeft, _ = makeXCoords clkCycleWidth (gap.Start) (NonBinaryTransition Change)
+    let _, xRight = makeXCoords clkCycleWidth (gap.Start+gap.Length-1) (NonBinaryTransition Change)
+
+    let crossHatchMidL, crossHatchTopL, crossHatchBotL =
+        {X = xLeft + xShift clkCycleWidth; Y = 0.5 * Constants.viewBoxHeight},
+        {X = xLeft + 2.0 * xShift clkCycleWidth; Y = Constants.yTop},
+        {X = xLeft + 2.0 * xShift clkCycleWidth; Y = Constants.yBot}
+    
+    let crossHatchMidR, crossHatchTopR, crossHatchBotR =
+        {X = xRight + xShift clkCycleWidth; Y = 0.5 * Constants.viewBoxHeight},
+        {X = xRight; Y = Constants.yTop},
+        {X = xRight; Y = Constants.yBot}
+
+    [| crossHatchMidL; crossHatchTopL; crossHatchTopR; crossHatchMidR; crossHatchBotR; crossHatchBotL; crossHatchMidL |]
 
 /// Determine transitions for each clock cycle of a binary waveform.
 /// Assumes that waveValues starts at clock cycle 0.

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -62,11 +62,6 @@ module Constants =
     let scrollbarHeight: float = 30.0
     /// <summary>Minimum width of the scrollbar thumb, in pixels.</summary>
     let scrollbarThumbMinWidth: float = 5.0
-    /// <summary>Width of buffer zone around scrollbar thumb, in pixels.
-    /// Scrollbar will run faster uni-directionally when mouse is in buffer zone.</summary>
-    let scrollbarThumbBufferWidth: float = 32.0
-    /// <summary>Speedup of scrolling if cursor hits buffer zone.</summary>
-    let scrollbarThumbBufferSpeedup: float = 4.0
 
 
 /// Style for top row in wave viewer.

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -61,7 +61,7 @@ module Constants =
     /// Currently set to same height as buttons.</summary>
     let scrollbarHeight: float = 30.0
     /// <summary>Minimum width of the scrollbar thumb, in pixels.</summary>
-    let scrollbarThumbMinWidth: float = 10.0
+    let scrollbarThumbMinWidth: float = 5.0
 
 
 /// Style for top row in wave viewer.

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -46,6 +46,8 @@ module Constants =
     let valueOnWaveText = { DrawHelpers.defaultText with FontSize = fontSizeValueOnWave }
     /// Whitespace padding between repeated values displayed on non-binary waves.
     let valueOnWavePadding = 75.0
+    /// Whitespace padding between non-binary wave values and the edge of transition.
+    let valueOnWaveEdgePadding = 8.0
 
     /// Border between columns and headers of waveform viewer.
     let borderProperties = "2px solid rgb(219,219,219)"
@@ -261,13 +263,24 @@ let zoomInSVG =
             ] []
         ]
 
-/// Props for displaying values on non-binary waves
-let valueOnWaveProps m i start width : IProp list = [
+/// <summary>Props for displaying repeating text elements on non-binary waves.</param>
+/// <remarks>Not used any more.</remarks>
+/// <param name="m"><c>WaveSim<c> model.</param>
+/// <param name="i">Index of text elements to be generated.</param>
+/// <param name="start">Starting position of repeating text elements.</param>
+/// <param name="width">Width of each text element.</param>
+let valueOnWaveProps m i start width : list<IProp> = [
     X (start * (singleWaveWidth m) + Constants.nonBinaryTransLen + float i * width)
     Y (0.6 * Constants.viewBoxHeight)
-    Style [
-        FontSize Constants.fontSizeValueOnWave
-    ]
+    Style [ FontSize Constants.fontSizeValueOnWave ]
+]
+
+/// <summary>Props for displaying values on non-binary waves by starting position.</summary>
+/// <param name="xpos">Starting X-direction position.</param>
+let singleValueOnWaveProps xpos: list<IProp> = [
+    X xpos
+    Y (0.6 * Constants.viewBoxHeight)
+    Style [ FontSize Constants.fontSizeValueOnWave ]
 ]
 
 /// Style for clock cycle buttons
@@ -637,6 +650,13 @@ let wavePolylineStyle points : IProp list = [
     SVGAttr.Stroke "blue"
     SVGAttr.Fill "none"
     SVGAttr.StrokeWidth Constants.lineThickness
+    Points (pointsToString points)
+]
+
+let wavePolyfillStyle points : IProp list = [
+    SVGAttr.Stroke "none"
+    SVGAttr.Fill "lightgrey"
+    SVGAttr.StrokeWidth (Constants.lineThickness+2.)
     Points (pointsToString points)
 ]
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -62,6 +62,11 @@ module Constants =
     let scrollbarHeight: float = 30.0
     /// <summary>Minimum width of the scrollbar thumb, in pixels.</summary>
     let scrollbarThumbMinWidth: float = 5.0
+    /// <summary>Width of buffer zone around scrollbar thumb, in pixels.
+    /// Scrollbar will run faster uni-directionally when mouse is in buffer zone.</summary>
+    let scrollbarThumbBufferWidth: float = 32.0
+    /// <summary>Speedup of scrolling if cursor hits buffer zone.</summary>
+    let scrollbarThumbBufferSpeedup: float = 4.0
 
 
 /// Style for top row in wave viewer.
@@ -757,7 +762,7 @@ let inline updateViewerWidthInWaveSim w (model:Model) =
         wsModel with
             ShownCycles = wholeCycles
             WaveformColumnWidth = finalWavesColWidth
-            ScrollbarWidth = scrollbarWidth
+            ScrollbarBkgWidth = scrollbarWidth
         }
 
     {model with WaveSimViewerWidth = w}

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -57,6 +57,11 @@ module Constants =
     /// Color for cursor and values column
     let cursorColor = "Lavender"
 
+    /// <summary>Height of scrollbar, in pixels. Affects only the SVG and not the buttons.
+    /// Currently set to same height as buttons.</summary>
+    let scrollbarHeight: float = 30.0
+    /// <summary>Minimum width of the scrollbar thumb, in pixels.</summary>
+    let scrollbarThumbMinWidth: float = 10.0
 
 
 /// Style for top row in wave viewer.
@@ -354,6 +359,18 @@ let clkCycleRightStyle = Style (
         BorderLeftWidth "0.5"
     ])
 
+// FIX: Should be refactored. This is a hack to force button style to NOT float right.
+/// <summary>Button style for scrollbar's right button. Left button uses <c>clkCycleLeftStyle</c>.</summary>
+let scrollbarClkCycleRightStyle = Style (
+    clkCycleBut @ [
+        BorderTopLeftRadius 0
+        BorderBottomLeftRadius 0
+        BorderTopRightRadius "4px"
+        BorderBottomRightRadius "4px"
+        BorderLeftWidth "0.5"
+        Float FloatOptions.Unset
+    ])
+
 /// Style for Bulma level element in name row
 let nameRowLevelStyle isHovered = Style [
     Height Constants.rowHeight
@@ -428,7 +445,7 @@ let waveSimColumn = [
 /// Style properties for names column
 let namesColumnStyle (ws:WaveSimModel) = Style (
     (waveSimColumn) @ [
-        MinWidth (calcNamesColWidth ws)
+        Width (calcNamesColWidth ws)
         Float FloatOptions.Left
         BackgroundColor Constants.cursorColor
         BorderRight Constants.borderProperties
@@ -724,17 +741,25 @@ let inline updateViewerWidthInWaveSim w (model:Model) =
 
     /// Require at least one visible clock cycle: otherwise choose number to get close to correct width of 1 cycle
     let wholeCycles = max 1 (int (float waveColWidth / singleWaveWidth wsModel))
-
-
     let singleCycleWidth = float waveColWidth / float wholeCycles
+    let finalWavesColWidth = singleCycleWidth * float wholeCycles
 
-    let viewerWidth = namesColWidth + Constants.valuesColWidth + int (singleCycleWidth * float wholeCycles) + otherDivWidths
+    /// Estimated length of scrollbar, adding three components together: names col, waveform port, and values col.
+    let scrollbarWidth = (float namesColWidth) + finalWavesColWidth + (float valuesColumnWidth)
+
+    // printfn "DEBUG:updateViewerWidthInWaveSim: Names Column Width = %Apx" (float namesColWidth)
+    // printfn "DEBUG:updateViewerWidthInWaveSim: Waves Column Width = %Apx" finalWavesColWidth
+    // printfn "DEBUG:updateViewerWidthInWaveSim: Values Column Width = %Apx" (float valuesColumnWidth)
+    // printfn "DEBUG:updateViewerWidthInWaveSim: Calculated Scrollbar Width = %Apx" scrollbarWidth
+
     let updateFn wsModel = 
         {
         wsModel with
             ShownCycles = wholeCycles
-            WaveformColumnWidth = singleCycleWidth * float wholeCycles
+            WaveformColumnWidth = finalWavesColWidth
+            ScrollbarWidth = scrollbarWidth
         }
+
     {model with WaveSimViewerWidth = w}
     |> ModelHelpers.updateWSModel updateFn
 

--- a/src/Renderer/UI/WaveSim/WaveSimStyle.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimStyle.fs
@@ -77,7 +77,7 @@ let topRowStyle = Style [
 
 /// Empty row used in namesColumn and valuesColumn. Shifts these down by one
 /// to allow for the row of clk cycle numbers in waveformsColumn.
-let topRow = [ div [ topRowStyle ] [] ]
+let topRow topRowContent = [ div [ topRowStyle ] topRowContent ]
 
 /// Style for showing error messages in waveform simulator.
 let errorMessageStyle = Style [
@@ -550,12 +550,22 @@ let showWaveformsStyle = Style [
 
 
 /// Props for text in clock cycle row
-let clkCycleText m i : IProp list = [
-    SVGAttr.FontSize "12px"
-    SVGAttr.TextAnchor "middle"
-    X (singleWaveWidth m * (float i + 0.5))
-    Y (0.6 * Constants.viewBoxHeight)
-]
+let clkCycleText m i : IProp list =
+    let props : IProp list =
+        [
+            SVGAttr.FontSize "12px"
+            SVGAttr.TextAnchor "middle"
+            X (singleWaveWidth m * (float i + 0.5))
+            Y (0.6 * Constants.viewBoxHeight)
+        ]
+    let cursorExtraProps : IProp list =
+        [
+            SVGAttr.Custom("font-weight", "bold")
+        ]
+    if i = m.CurrClkCycle then
+        cursorExtraProps @ props
+    else
+        props
 
 /// Style for clock cycle number row
 let clkCycleSVGStyle = Style [


### PR DESCRIPTION
### Summary

* **Improved Wave SVG Generation**:
    * Generate only viewable bits os waveform SVG, decreasing generation speed by 10x.
    * Increase max number of cycles allowed to 10k, since it is detached from SVG generation and memory space.
    * Add grey polygons to denote value change when space is too tight to display numerics.
    * Add new numerics display method to show two copies of numbers at ends instead of multiple copies across.
* **Waveform Simulator Scrollbar**:
    * Add scrollbar to allow for fluidly searching for waveforms. 

### Issues Resolved

* Directly addressed: #332, #442, and #448.
* Indirectly assisted: #447.