### PR TITLE
Fix Waveform Simulator Hovering Not Working After Specific Drag

### DIFF
--- a/src/Renderer/UI/WaveSim/WaveSimWaveforms.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimWaveforms.fs
@@ -104,7 +104,7 @@ let nameRows (model: Model) (wsModel: WaveSimModel) dispatch: ReactElement list 
                         
                 )
                 OnMouseOut (fun _ ->
-                    dispatch <| SetWSModel {wsModel with HoveredLabel = None}
+                    dispatch <| SetWSModel {wsModel with HoveredLabel = None; DraggedIndex = None; PrevSelectedWaves = None }
                     dispatch <| Sheet (SheetT.Msg.Wire (BusWireT.Msg.Symbol (SymbolT.SelectSymbols [])))
                     dispatch <| Sheet (SheetT.Msg.UpdateSelectedWires (connsOfWave (Simulator.getFastSim()) wave, false))
                 )
@@ -146,7 +146,7 @@ let nameRows (model: Model) (wsModel: WaveSimModel) dispatch: ReactElement list 
                     ev.dataTransfer.dropEffect <- "move"
                     let nameColEl = Browser.Dom.document.getElementById "namesColumn"
                     let bcr = nameColEl.getBoundingClientRect ()
-                    let index = int (ev.clientY - bcr.top) / Constants.rowHeight - 1
+                    let index = int (ev.clientY - bcr.top) / Constants.rowHeight - 1 |> max 0 |> min (List.length wsModel.SelectedWaves)
                     let draggedWave =
                         match wsModel.DraggedIndex with
                         | Some waveId -> [waveId]


### PR DESCRIPTION
**Steps to recreate the bug**
 
Try the following steps:

1. Open Waveform Simulator like you usually would.
2. Click and drag any element from the position slightly above the text. Any element can be used, but I find the first element to be the easiest.
3. Drag said element until the bottom border starts to cover the top of the scrollbar.
4. Release and check if is hover is broken. If not, repeat steps 2 to 4, which slight altering the position where you start to drag the element.
 
This method is the most reliable way to recreate the bug, I have found. It has a success rate of about 1 in 4 tries.
 
**What was broken**
 
This bug is caused by the OnDragEnd handler and OnMouseOut handler being fired back-to-back, without the showWaveform function being called in between. What this meant was, after the OnDragEnd dispatches a SetWsModel message to clear the DraggedIndex field, the OnMouseOut also fires a SetWsModel message to set some other field. But since its DraggedIndex field was obtained before the first SetWsModel message fired by OnDragEnd was executed (due to no showWaveform call), it overrides the DraggedIndex field with incorrect information. This indirectly causes the hover mechanism to not work, as the OnMouseOver handler checks the DraggedIndex field to decide whether to highlight waveforms or not.
 
This is proven with the following dev logs. We first look at how a drag that does not break the hover mechanism fires in Figure 1, we note the sequence of: OnDragEnd > showWaveform > OnMouseOut. We then compare with a drag that does break the hover mechanism in Figure 2, we note that the sequence has now changed to: OnDragEnd > OnMoueOut, missing showWaveform in between. Each event handler message has been tagged with wsModel.DraggedIndex.IsSome field it dispatches as well: the OnMouseOut message does in fact dispatches content that is different to OnDragEnd.
 
_Figure 1 – Normal Drag Operation_
<img width="1250" alt="Normal Drag" src="https://github.com/user-attachments/assets/140625f2-2a3a-492f-a322-ce27a2f4cc26">

_Figure 2 – Abnormal Drag Operation_
<img width="1246" alt="Abnormal Drag" src="https://github.com/user-attachments/assets/119e034f-40db-47a2-a550-c368e0cec52d">

**Mitigation**
 
The mitigation is simple: always set the DraggedIndex to None when the OnMouseOut event is fired: now even though the events were still fired back-to-back, the data given to the SetWsModel message instead contains the correct DraggedIndex state. See Figure 3.
 
_Figure 3 – After Fix_
<img width="1244" alt="After-Fix Drag" src="https://github.com/user-attachments/assets/a6bf49fb-bc19-4747-8779-1c09d06de72b">

Additionally, a min/max cap was used on the index of the OnDrag handler before being passed to insertManyAt.