### PR TITLE
Configure package.json for macOS arm64 and x64 binaries and sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ docsrc/tools/FSharp.Formatting.svclog
 .fsdocs/
 output/
 tmp/
+
+# macOS compilation
+*.provisionprofile

--- a/package.json
+++ b/package.json
@@ -59,18 +59,24 @@
       "category": "public.app-category.productivity",
       "entitlements": "public/entitlements.mac.plist",
       "entitlementsInherit": "./public/entitlements.mac.plist",
-      "identity": "F7735AA14D8A32CE021D86077797AE9457C53603",
       "icon": "public/icon.icns",
       "target": [
-        "dmg"
+        {
+          "target": "dmg",
+          "arch": "x64"
+        }, {
+          "target": "dmg",
+          "arch": "arm64"
+        }
       ],
       "hardenedRuntime": true,
-      "provisioningProfile": "embedded.provisionprofile"
+      "identity": "4ADD6B8606BC9F3C2124FEF100B9C828B58EF06E",
+      "provisioningProfile": "issie.provisionprofile",
+      "notarize": true
     },
     "dmg": {
       "icon": false
-    },
-    "afterAllArtifactBuild": "scripts/afterSignHook.js"
+    }
   },
   "dependencies": {
     "@electron/remote": "^2",


### PR DESCRIPTION
**Summary**

1. Updated `package.json` to compile for both `arm64` and `x64` macOS binaries. Verified working on Apple Silicon Macs, not sure if cross-platform compilation works on Intel Macs.
2. Use `electron-builder` default notarization instead of `electron-notarize` in `scripts/afterSignHook.js`.

For more details, see wiki page: [Signing and Notarizing ISSIE For MacOS](https://github.com/tomcl/issie/wiki/Signing-and-Notarizing-ISSIE-For-MacOS).