### PR TITLE
New Zoom In/Out

### DIFF
--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -416,7 +416,22 @@ let displayView model dispatch =
             UIPopups.viewPopup model dispatch  
 
             if model.PopupDialogData.Progress = None then
-                SheetDisplay.view model.Sheet headerHeight (canvasVisibleStyleList model) sheetDispatch
+                div [ 
+                    OnWheel (fun (e: Browser.Types.WheelEvent) ->
+                        if e.ctrlKey || e.metaKey then
+                            e.preventDefault()
+                            dispatch (Sheet (
+                                if e.deltaY > 0. then
+                                    SheetT.KeyPress SheetT.KeyboardMsg.ZoomOut
+                                else
+                                    SheetT.KeyPress SheetT.KeyboardMsg.ZoomIn
+                                ))
+                        else
+                            ()
+                        );
+                ] [
+                    SheetDisplay.view model.Sheet headerHeight (canvasVisibleStyleList model) sheetDispatch
+                ]
 
             Notifications.viewNotifications model dispatch
             let wsModel = ModelHelpers.getWSModel model


### PR DESCRIPTION
This code handles `Ctrl + Mouse Wheel` (or `Cmd + Mouse Wheel`) for zooming in and out within a specific area. 

### Highlights:
1. **Zoom Control**: Scrolling up triggers `ZoomIn`, scrolling down triggers `ZoomOut`, only when `Ctrl` or `Cmd` is pressed.
2. **Effect Limitation**: The zoom effect is confined to a specific `div` on `MainView`, preventing interference with other parts of the page and the whole electron.