### PR TITLE
fix #507

### DIFF
--- a/src/Renderer/DrawBlock/BusWireRoutingHelpers.fs
+++ b/src/Renderer/DrawBlock/BusWireRoutingHelpers.fs
@@ -168,8 +168,10 @@ with member this.Index = match this with | LineId i -> i
 
 [<StringEnum>]
 type LType = 
-    /// a non-segment fixed (symbol boundary) barrier
-    | BARRIER  
+    /// a non-segment fixed (symbol boundary) barrier extending in positive direction
+    | BARRIERPOS
+    /// a non-segment fixed (symbol boundary) barrier extending in negative direction
+    | BARRIERNEG
     /// a movable line segment
     | NORMSEG 
     /// a segment which is a fixed barrier in clustering but can change after.


### PR DESCRIPTION
This is a fix for the issue but does not prevent auto-routing from making 4 segment wires go through components, nor fix this up.