### PR TITLE
Add parameter inheritance

### DIFF
--- a/src/Renderer/Common/ParameterTypes.fs
+++ b/src/Renderer/Common/ParameterTypes.fs
@@ -46,7 +46,7 @@ type CompSlotName =
     | Buswidth
     | NGateInputs
     | IO of Label: string
-    | CustomCompParam of ParamName: string // TODO-RYAN: Should this have type ParamName??
+    | CustomCompParam of ParamName: ParamName   // Custom component parameter binding
     | SheetParam of ParamName: ParamName    // Used to update default sheet parameters
 
 /// A slot in a component instance that can be bound to a parameter expression

--- a/src/Renderer/Common/ParameterTypes.fs
+++ b/src/Renderer/Common/ParameterTypes.fs
@@ -40,13 +40,14 @@ type ParamConstraint =
     | MaxVal of ParamExpression * ParamError
 
 /// A string marking a specific integer value in a case of ComponentType.
-/// The values here are arbitrary and ComponentType-case specific and all that matters is that each value is unique
-/// within the case.
+/// The values here are arbitrary and ComponentType-case specific and all
+/// that matters is that each value is unique within the case.
 type CompSlotName =
     | Buswidth
     | NGateInputs
     | IO of Label: string
-    | CustomCompParam of ParamName: string // TODO: implement this case
+    | CustomCompParam of ParamName: string // TODO-RYAN: Should this have type ParamName??
+    | SheetParam of ParamName: ParamName    // Used to update default sheet parameters
 
 /// A slot in a component instance that can be bound to a parameter expression
 /// CompId should be a ComponentId but then we would need these types to be defined after CommonTypes.
@@ -78,9 +79,6 @@ type ParamBoxDialogState = Map<CompSlotName, Result<NewParamCompSpec, ParamError
 /// Map from name to expression for each parameter
 type ParamBindings = Map<ParamName, ParamExpression>
 
-
-/// For Part A: alternatively you could store slot information in the component record
-/// as an extra field.
 /// This field should store all the Component's slot information where slots are bound to parameters.
 type ComponentSlotExpr = Map<ParamSlot, ConstrainedExpr>
 

--- a/src/Renderer/Common/ParameterTypes.fs
+++ b/src/Renderer/Common/ParameterTypes.fs
@@ -91,6 +91,13 @@ type ParameterDefs = {
     ParamSlots: ComponentSlotExpr
 }
 
+/// Config for a parameter popup dialog box
+type PopupConfig = {
+    Title: string
+    Prompt: string
+    Button: string
+}
+
 /// Lenses for ParamDefs
 let defaultBindings_ = Optics.Lens.create (fun s -> s.DefaultBindings) (fun v s -> {s with DefaultBindings = v})
 let paramSlots_ = Optics.Lens.create (fun s -> s.ParamSlots) (fun v s -> {s with ParamSlots = v})

--- a/src/Renderer/Common/ParameterTypes.fs
+++ b/src/Renderer/Common/ParameterTypes.fs
@@ -94,6 +94,3 @@ type ParameterDefs = {
 /// Lenses for ParamDefs
 let defaultBindings_ = Optics.Lens.create (fun s -> s.DefaultBindings) (fun v s -> {s with DefaultBindings = v})
 let paramSlots_ = Optics.Lens.create (fun s -> s.ParamSlots) (fun v s -> {s with ParamSlots = v})
-
-
-

--- a/src/Renderer/DrawBlock/BusWireUpdate.fs
+++ b/src/Renderer/DrawBlock/BusWireUpdate.fs
@@ -458,6 +458,9 @@ let update (msg : Msg) (issieModel : ModelType.Model) : ModelType.Model*Cmd<Mode
     | ToggleSnapToNet ->
         {issieModel with Sheet={ issieModel.Sheet with Wire={model with SnapToNet = not model.SnapToNet}}} |> withNoMsg
     
+    | DeleteParamSlots compIds ->
+        withIssieMsg (ModelType.DeleteParamSlots compIds) issieModel
+
 
 //---------------------------------------------------------------------------------//        
 //---------------------------Other interface functions-----------------------------//

--- a/src/Renderer/DrawBlock/SymbolUpdate.fs
+++ b/src/Renderer/DrawBlock/SymbolUpdate.fs
@@ -698,14 +698,15 @@ let ChangeSplitN (compId, numInputs, widths, lsbs) model =
 
 
 /// Update function which displays symbols
-let update (msg : Msg) (model : Model): Model*Cmd<'a>  =     
+let update (msg : Msg) (model : Model): Model*Cmd<BusWireT.Msg> =     
     match msg with
     | UpdateBoundingBoxes ->
         // message used to update symbol bounding boxes in sheet.
         failwithf "What? This message is intercepted by Sheet update function and never found here"
     | DeleteSymbols compIds ->
         // printfn "update msg: DeleteSymbol"
-        (deleteSymbols model compIds), Cmd.none
+        let cmd = Cmd.ofMsg <| BusWireT.Msg.DeleteParamSlots compIds
+        (deleteSymbols model compIds), cmd
 
     | AddSymbol (ldcs, pos,compType, lbl) ->
         // printfn "update msg: AddSymbol"

--- a/src/Renderer/Model/DrawModelType.fs
+++ b/src/Renderer/Model/DrawModelType.fs
@@ -407,6 +407,7 @@ module BusWireT =
         | UpdateConnectedWires of list<ComponentId> // rotate each symbol separately. TODO - rotate as group? Custom comps do not rotate
         | RerouteWire of string
         | ToggleSnapToNet
+        | DeleteParamSlots of list<ComponentId>
 
     let symbol_ = Lens.create (fun m -> m.Symbol) (fun w m -> {m with Symbol = w})
     let wires_ = Lens.create (fun m -> m.Wires) (fun w m -> {m with Wires = w})

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -547,6 +547,7 @@ type Msg =
     | UpdatePopupProgress of (PopupProgress -> PopupProgress)
     | SimulateWithProgressBar of SimulationProgress
     | SetSelectedComponentMemoryLocation of bigint * bigint
+    | DeleteParamSlots of ComponentId list
     | CloseDiagramNotification
     | SetSimulationNotification of ((Msg -> unit) -> ReactElement)
     | CloseSimulationNotification

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -332,6 +332,7 @@ let private createArithmeticPopup compType (model: Model) dispatch =
             dispatch <| ReloadSelectedComponent compParamSpec.Value
             dispatch ClosePopup
 
+    // TODO-RYAN: Refactor this using new paramFieldIsDisabled function
     let isDisabled =
         fun model' ->
             model'.PopupDialogData.DialogState

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -306,7 +306,7 @@ let private createArithmeticPopup compType (model: Model) dispatch =
         MinVal (PInt 1, $"Number of bits in {compName} must be positive")
     ]
  
-    let paramSpec = {
+    let compSpec = {
         CompSlot = Buswidth
         Expression = PInt model.LastUsedDialogWidth
         Constraints = constraints
@@ -314,7 +314,7 @@ let private createArithmeticPopup compType (model: Model) dispatch =
     }
 
     let buttonAction model' =
-        let compSpec = getParamFieldSpec paramSpec.CompSlot model'
+        let compSpec = getParamFieldSpec compSpec.CompSlot model'
         let comp = toComp compSpec.Value
         let addParamCompFunction = Some <| addParamComponent compSpec dispatch
         
@@ -322,7 +322,7 @@ let private createArithmeticPopup compType (model: Model) dispatch =
         dispatch <| ReloadSelectedComponent compSpec.Value
         dispatch ClosePopup
 
-    paramPopupBox popupConfig paramSpec None buttonAction dispatch
+    paramPopupBox popupConfig compSpec None buttonAction dispatch
 
 
 let private createNbitSpreaderPopup (model:Model) dispatch =
@@ -502,7 +502,7 @@ let private createRegisterPopup regType (model:Model) dispatch =
         Button = "Add"
     }
 
-    let paramSpec = {
+    let compSpec = {
         CompSlot = Buswidth
         Expression = PInt model.LastUsedDialogWidth
         Constraints = [MinVal (PInt 1, "Register width must be positive")]
@@ -510,7 +510,7 @@ let private createRegisterPopup regType (model:Model) dispatch =
     }
 
     let buttonAction model' =
-        let compSpec = getParamFieldSpec paramSpec.CompSlot model'
+        let compSpec = getParamFieldSpec compSpec.CompSlot model'
         let comp = toComp compSpec.Value
         let addParamCompFunction = Some <| addParamComponent compSpec dispatch
 
@@ -518,7 +518,7 @@ let private createRegisterPopup regType (model:Model) dispatch =
         dispatch <| ReloadSelectedComponent compSpec.Value
         dispatch ClosePopup
 
-    paramPopupBox popupConfig paramSpec None buttonAction dispatch
+    paramPopupBox popupConfig compSpec None buttonAction dispatch
 
 
 let private createMemoryPopup memType model (dispatch: Msg -> Unit) =

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -311,7 +311,7 @@ let private createArithmeticPopup compType (model: Model) dispatch =
     }
 
     let inputField model' =
-        ParameterView.paramInputField model' prompt intDefault None constraints None slot dispatch
+        ParameterView.paramInputField model' prompt intDefault constraints None slot dispatch
 
     let buttonAction =
         fun (model': Model) ->
@@ -531,7 +531,7 @@ let private createRegisterPopup regType (model:Model) dispatch =
     }
 
     let inputField model' =
-        ParameterView.paramInputField model' prompt intDefault None constraints None slot dispatch
+        ParameterView.paramInputField model' prompt intDefault constraints None slot dispatch
 
     let buttonText = "Add"
     let buttonAction =

--- a/src/Renderer/UI/ParameterView.fs
+++ b/src/Renderer/UI/ParameterView.fs
@@ -407,8 +407,7 @@ let rec checkAllCompSlots
     paramSlots
     |> Map.map addDetailedErrorMsg
     |> Map.map checkSlot
-    |> Map.values
-    |> List.ofArray
+    |> Map.valuesL
     |> List.filter Result.isError
     |> function
         | [] -> Ok ()

--- a/src/Renderer/UI/ParameterView.fs
+++ b/src/Renderer/UI/ParameterView.fs
@@ -767,16 +767,17 @@ let paramInputField
         | _ -> failwithf "Value cannot exist with invalid expression"
 
     // Get the input expression and error message as strings
-    let inputString =
+    // TODO-RYAN: Tidy this up using result properly
+    let boxValue, exprString =
         model.PopupDialogData.DialogState
         |> Option.defaultValue Map.empty
         |> Map.tryFind compSpec.CompSlot
         |> Option.map (
             function
-            | Ok newCompSpec -> renderParamExpression newCompSpec.Expression 0
-            | Error _ -> string compSpec.Value
+            | Ok newCompSpec -> newCompSpec.Value, renderParamExpression newCompSpec.Expression 0
+            | Error _ -> compSpec.Value, string compSpec.Value
         )
-        |> Option.defaultValue (string compSpec.Value)
+        |> Option.defaultValue (compSpec.Value, string compSpec.Value)
 
     let errText = 
         model.PopupDialogData.DialogState
@@ -805,15 +806,15 @@ let paramInputField
                         AutoFocus true
                         Style [Width "200px"]
                     ]
-                    Input.DefaultValue <| inputString
+                    Input.DefaultValue <| exprString
                     Input.Type Input.Text
                     Input.OnChange (getTextEventValue >> onChange)
                 ]
             ]
-            if errText = "" && string compSpec.Value <> inputString then
+            if errText = "" && string boxValue <> exprString then
                 Control.p [] [
                     Button.a [Button.Option.IsStatic true] [
-                        str (string compSpec.Value)
+                        str (string boxValue)
                     ]
                 ]
         ]

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -26,6 +26,7 @@ open CatalogueView
 open TopMenuView
 open MenuHelpers
 open ParameterTypes
+open ParameterView
 
 open CatalogueView.Constants
 
@@ -469,7 +470,7 @@ let private makeScaleAdjustmentField model (comp:Component) dispatch =
 
 
 let private makeNumberOfBitsField model (comp: Component) text dispatch =    
-    let title, width, slot =
+    let prompt, width, slot =
         match comp.Type with
         | Input1 (w, _) | Output w -> "Number of bits", w, IO comp.Label
         | NbitsAdder w | NbitsAdderNoCin w | NbitsAdderNoCout w | NbitsAdderNoCinCout w
@@ -485,9 +486,14 @@ let private makeNumberOfBitsField model (comp: Component) text dispatch =
         | Constant1 (w, _, _) -> "Number of bits in the wire", w, Buswidth
         | c -> failwithf $"makeNumberOfBitsField called with invalid component: {c}"
 
-    let constraints = [MinVal (PInt 1, $"{title} must be positive")]
+    let compSpec = {
+        CompSlot = slot
+        Expression = PInt width
+        Constraints = [MinVal (PInt 1, $"{prompt} must be positive")]
+        Value = width
+    }
 
-    ParameterView.paramInputField model title width constraints (Some comp) slot dispatch
+    paramInputField model prompt compSpec (Some comp) dispatch
 
 
 let private makeNumberOfInputsField model (comp: Component) dispatch =
@@ -501,7 +507,14 @@ let private makeNumberOfInputsField model (comp: Component) dispatch =
         MaxVal (PInt maxGateInputs, $"Cannot have more than {maxGateInputs} inputs")
     ]
 
-    ParameterView.paramInputField model prompt nInp constraints (Some comp) NGateInputs dispatch
+    let compSpec = {
+        CompSlot = NGateInputs
+        Expression = PInt nInp
+        Constraints = constraints
+        Value = nInp
+    }
+
+    paramInputField model prompt compSpec (Some comp) dispatch
 
 
 let private changeMergeN model (comp:Component) dispatch =

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -514,6 +514,7 @@ let private makeNumberOfInputsField model (comp: Component) dispatch =
         Value = nInp
     }
 
+    dispatch <| ClearPopupDialogParamSpec compSpec.CompSlot
     paramInputField model prompt compSpec (Some comp) dispatch
 
 

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -487,7 +487,7 @@ let private makeNumberOfBitsField model (comp: Component) text dispatch =
 
     let constraints = [MinVal (PInt 1, $"{title} must be positive")]
 
-    ParameterView.paramInputField model title 1 (Some width) constraints (Some comp) slot dispatch
+    ParameterView.paramInputField model title width constraints (Some comp) slot dispatch
 
 
 let private makeNumberOfInputsField model (comp: Component) dispatch =
@@ -501,7 +501,7 @@ let private makeNumberOfInputsField model (comp: Component) dispatch =
         MaxVal (PInt maxGateInputs, $"Cannot have more than {maxGateInputs} inputs")
     ]
 
-    ParameterView.paramInputField model prompt  1 (Some nInp) constraints (Some comp) NGateInputs dispatch
+    ParameterView.paramInputField model prompt nInp constraints (Some comp) NGateInputs dispatch
 
 
 let private changeMergeN model (comp:Component) dispatch =

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -561,6 +561,16 @@ let update (msg : Msg) oldModel =
         |> map selectedComponent_ (updateComponentMemory addr data)
         |> withNoMsg
 
+    | DeleteParamSlots compIds ->
+        let updateSlots (paramSlots: ParameterTypes.ComponentSlotExpr) =
+            paramSlots
+            |> Map.filter (
+                fun slot _ -> not <| List.contains (ComponentId slot.CompId) compIds
+            )
+        model
+        |> map ParameterView.paramSlotsOfModel_ updateSlots
+        |> withNoMsg
+
     | CloseDiagramNotification ->
         model
         |> set (notifications_ >-> fromDiagram_) None

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -175,6 +175,7 @@ let shortDisplayMsg (msg:Msg) =
     | UpdatePopupProgress _ 
     | SimulateWithProgressBar _ -> None
     | SetSelectedComponentMemoryLocation _ -> Some "SetSelectedComponentMemoryLocation"
+    | DeleteParamSlots _
     | CloseDiagramNotification
     | SetSimulationNotification _ 
     | CloseSimulationNotification


### PR DESCRIPTION
Summary of changes:
- Add multi-level parameter inheritance. Custom components can now have their bindings set to parameter expressions.
- Add detailed error messages to support parameter inheritance. If any of the constraints of a lower-level component would be broken by a new binding in a higher-level sheet, the specific component and broken constraint are highlighted.
- Hide parameter evaluation result boxes next to input field when there is an error message.
- Make parameter evaluation result boxes appear for all expressions other than simple integer constants, including those which do not contain parameters.
- Make corresponding parameter slots be deleted when a component is deleted.
- Fix bug with previous parameter error messages reappearing when a component is reselected.
- General code tidy-up in `ParameterView.fs`.