### PR TITLE
Fix CD Workflow Check Latest Release Repo Bug

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -19,7 +19,7 @@ jobs:
       id: latest_release
       uses: KevinRohn/github-full-release-data@v2
       with:
-        repository: samuelpswang/issie-dev-workflow
+        repository: ${{ github.repository }}
         token: ${{ secrets.GITHUB_TOKEN }}
         version: latest
     - name: Check if this tag is a patch


### PR DESCRIPTION
In the current `build_dist.yml`, the first step is to check for the latest release of a repo. This was previously erronously hard-coded to the test repo, but is corrected to the correct [workflow context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability) now and no longer hard-coded.