### PR TITLE
Fix build-linux step in build.yml workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,9 @@ jobs:
         security set-key-partition-list -S apple-tool:,apple: -k "$APPLE_KEYCHAIN_TMP_PWD" $KEYCHAIN_PATH
         security list-keychain -d user -s $KEYCHAIN_PATH
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '8.0.319'
     - name: Checkout the repo
       uses: actions/checkout@v5
       with:
@@ -149,9 +149,9 @@ jobs:
     needs: update-current-release
     steps:
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '8.0.319'
     - name: Set up required Ubuntu packages
       run: |
         sudo apt-get update
@@ -175,9 +175,9 @@ jobs:
     needs: update-current-release
     steps:
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '8.0.319'
     - name: Checkout the repo
       uses: actions/checkout@v5
       with:


### PR DESCRIPTION
### Feature

Fable (`dotnet-fable@4.24.0`) hangs on Linux runners (`ubuntu-24.04`) when used with .NET SDK 10 (`dotnet@10.0.x`), which is the default version installed on GitHub runners at time of writing. The action `actions/setup-dotnet@v4` does not remove other versions of .NET SDK, and any calls to `dotnet` CLI uses the latest version available on the system.

To fix this, `actions/setup-dotnet@v2` was used instead, which _does_ remove all other versions.

Another solution to this would be to provide a `global.json`, which was not chosen here as it compilcates the build system further.

### Commits

* [fix: build-linux stage in build.yml by updating dotnet sdk version](https://github.com/tomcl/issie/commit/b9491d7e74c1b7916c8f965cdec9b50dcf1d6a8c)

### References

1. Fable CLI fails on Github CI #11434, access [here](https://github.com/actions/runner-images/issues/11434).
2. Select the .NET version to use, access [here](https://learn.microsoft.com/en-us/dotnet/core/versions/selection).
