### PR TITLE
fix(sim): n-bit spreader breaking due to 32-bit overflow

### DIFF
--- a/src/Renderer/Simulator/FastSim/FastReduce.fs
+++ b/src/Renderer/Simulator/FastSim/FastReduce.fs
@@ -854,7 +854,7 @@ let fastReduce (maxArraySize: int) (numStep: int) (isClockedReduction: bool) (co
         let res =
             match a with
             | 0u -> 0u
-            | 1u -> (1u <<< numberOfBits) - 1u
+            | 1u -> if numberOfBits <> 32 then (1u <<< numberOfBits) - 1u else UInt32.MaxValue
             | _ -> failwithf $"Can't happen"
 
         putUInt32 0 res

--- a/src/Renderer/Simulator/FastSim/FastReduceTT.fs
+++ b/src/Renderer/Simulator/FastSim/FastReduceTT.fs
@@ -796,7 +796,10 @@ let fastReduceFData (maxArraySize: int) (numStep: int) (isClockedReduction: bool
                 | 0u -> convertIntToFastData numberOfBits 0u
                 | 1u ->
                     match numberOfBits with
-                    | n when n <= 32 -> convertIntToFastData numberOfBits ((1u <<< numberOfBits) - 1u)
+                    | n when n <= 32 -> 
+                        convertIntToFastData 
+                            numberOfBits 
+                            (if numberOfBits <> 32 then ((1u <<< numberOfBits) - 1u) else UInt32.MaxValue)
                     | _ -> convertBigintToFastData numberOfBits ((1I <<< numberOfBits) - 1I)
                 | _ -> failwithf $"Can't happen"
 


### PR DESCRIPTION
NbitSpreader in simulation uses (a.) unsigned 32 bit intergers up to width = 32 and (b.) the shift and minus 1 mechanism to get all 1s in its output. This mechanism breaks exactly at 32 bit, which was what was reported in #598.