### PR TITLE
Configure dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    target-branch: "dependabot"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "samuelpswang"
+  - package-ecosystem: "dotnet-sdk"
+    target-branch: "dependabot"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "samuelpswang"
+  - package-ecosystem: "nuget"
+    target-branch: "dependabot"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "samuelpswang"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,21 @@ version: 2
 
 updates:
   - package-ecosystem: "npm"
-    target-branch: "dependabot"
+    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
       - "samuelpswang"
   - package-ecosystem: "dotnet-sdk"
-    target-branch: "dependabot"
+    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
       - "samuelpswang"
   - package-ecosystem: "nuget"
-    target-branch: "dependabot"
+    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
- Add `.github/dependabot.yml` for Dependabot to target `dependabot-integration` instead of `master` branch. Allows updating Dependabot PRs without pushing to `master`.