### PR TITLE
Take the dependency updates that apply, and stop the bot proposing ones that do not

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,26 @@
 version: 2
 
+# These target the default branch. They used to target dependabot-integration,
+# which drifted 119 commits behind master, so the updates were being proposed
+# against a manifest that no longer existed - electron 35, react 17, and
+# dependencies master had already dropped. Every such PR was unmergeable by
+# construction, and the versions being "bumped to" were in several cases older
+# than what master already locked.
+
 updates:
   - package-ecosystem: "npm"
-    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
       - "samuelpswang"
   - package-ecosystem: "dotnet-sdk"
-    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
       - "samuelpswang"
   - package-ecosystem: "nuget"
-    target-branch: "dependabot-integration"
     directory: "/"
     schedule:
       interval: "daily"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issie",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issie",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@electron/remote": "^2",
@@ -20,7 +20,7 @@
         "react-tooltip": "^5",
         "source-map-support": "^0.5",
         "usb": "^2.15",
-        "uuid": "^11.1.1"
+        "uuid": "^14.0.1"
       },
       "devDependencies": {
         "@electron/notarize": "^3",
@@ -296,9 +296,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2343,9 +2343,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4224,9 +4224,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4320,9 +4320,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8059,6 +8059,20 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8843,16 +8857,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "katex": "^0.16.21",
         "react-tooltip": "^5",
         "source-map-support": "^0.5",
-        "usb": "^2.15",
+        "usb": "^3.0.1",
         "uuid": "^14.0.1"
       },
       "devDependencies": {
@@ -935,6 +935,178 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@node-usb/usb-darwin-arm64": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-darwin-arm64/-/usb-darwin-arm64-3.0.1.tgz",
+      "integrity": "sha512-GB+MGKaXvEtaDOWng7nCPxWvnXWhZtbFL0FW9ncDmGYtFl3OW+xfLZGhd5Y9VKG6GXXIYS3x1FsBI+zkcxVMhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-darwin-x64": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-darwin-x64/-/usb-darwin-x64-3.0.1.tgz",
+      "integrity": "sha512-oTY8vLoigjYFwNft1nZNNje0zAXjSQy9u3swe+pcCfZp6qQbEoSLegLEBr94arEgQloQabaq4VA2JZVA8cUQqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-linux-arm-gnueabihf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-linux-arm-gnueabihf/-/usb-linux-arm-gnueabihf-3.0.1.tgz",
+      "integrity": "sha512-GN5dTxc/FhjmC9NP7Xx1esGAhpIhnNvAf02kk/0i7Cz0w1VaJ/I0XbIVAYIJ5zhDg/oSYkhdILHbOS9+mlWCRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-linux-arm64-gnu": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-linux-arm64-gnu/-/usb-linux-arm64-gnu-3.0.1.tgz",
+      "integrity": "sha512-7cL85qb/yrBXvssZwL3k62duBxT/LaCY/Vcfv/Du9MLFdHhqU0zdYX5fLch/zaW5euYXQE0gmCoTfimfAjlxGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-linux-arm64-musl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-linux-arm64-musl/-/usb-linux-arm64-musl-3.0.1.tgz",
+      "integrity": "sha512-EweA4HeTwzLiRHsU2DRFflJ3vx0shB5Z9Lt5/P/bkoUtSNt8uGjFCmsCjqoO068ul9oejsBMJg22rNLD3+iFqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-linux-x64-gnu": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-linux-x64-gnu/-/usb-linux-x64-gnu-3.0.1.tgz",
+      "integrity": "sha512-cEE7GyMhtfq5OM/MXZn3RmYBqPvId0CMuoBx7biazPvlnf0iEWYjpma0WvVMWad/f1QIcC45WgrazHaVv6gAPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-linux-x64-musl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-linux-x64-musl/-/usb-linux-x64-musl-3.0.1.tgz",
+      "integrity": "sha512-zGWlk1mzElTPO4wxlRcd1C7xd7xDxzgpOXbQfE+NbClOUJ71NkbnahWN2ef2LcJvFESYg/CV9Dv/ULKSpJWEEw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-win32-arm64-msvc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-win32-arm64-msvc/-/usb-win32-arm64-msvc-3.0.1.tgz",
+      "integrity": "sha512-ayXNeb+KvdkZLXzTWyttNONUPG8/x9PwuP+GvUeiYCQuyLMqmbGeMsO7IiuBWTnxLFtCdep+UBpcL8XMcYdTiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-win32-ia32-msvc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-win32-ia32-msvc/-/usb-win32-ia32-msvc-3.0.1.tgz",
+      "integrity": "sha512-U5281i6yY7gtoTwLom8nLF2o+ILI/g4OFpbAJBr4GbVPOTu+CSNF2Ea+dLEAG30148mp8v79NEsIiAbWXS/1aw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@node-usb/usb-win32-x64-msvc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@node-usb/usb-win32-x64-msvc/-/usb-win32-x64-msvc-3.0.1.tgz",
+      "integrity": "sha512-T1jzCBwgnA6E5otxJS/j44b//6fGzHSDmLQtNN1fX6JvdQIisgtbf2+iKD/YI7E247j6Yi9Ixt+MKjHt64hugA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -6140,15 +6312,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -6188,6 +6351,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -8797,18 +8961,27 @@
       }
     },
     "node_modules/usb": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
-      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
-      "hasInstallScript": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-3.0.1.tgz",
+      "integrity": "sha512-IQIi5EraqmKssMNcXe7afKhriHFAE5WdfykhvgkOschJyHBkJXtk/PDx/DzVNyfI7qdr+BUbmLziXA+I3z02lw==",
       "license": "MIT",
       "dependencies": {
-        "@types/w3c-web-usb": "^1.0.6",
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.5.0"
+        "@types/w3c-web-usb": "^1.0.14"
       },
       "engines": {
-        "node": ">=12.22.0 <13.0 || >=14.17.0"
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      },
+      "optionalDependencies": {
+        "@node-usb/usb-darwin-arm64": "3.0.1",
+        "@node-usb/usb-darwin-x64": "3.0.1",
+        "@node-usb/usb-linux-arm-gnueabihf": "3.0.1",
+        "@node-usb/usb-linux-arm64-gnu": "3.0.1",
+        "@node-usb/usb-linux-arm64-musl": "3.0.1",
+        "@node-usb/usb-linux-x64-gnu": "3.0.1",
+        "@node-usb/usb-linux-x64-musl": "3.0.1",
+        "@node-usb/usb-win32-arm64-msvc": "3.0.1",
+        "@node-usb/usb-win32-ia32-msvc": "3.0.1",
+        "@node-usb/usb-win32-x64-msvc": "3.0.1"
       }
     },
     "node_modules/utf-8-validate": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "katex": "^0.16.21",
     "react-tooltip": "^5",
     "source-map-support": "^0.5",
-    "usb": "^2.15",
+    "usb": "^3.0.1",
     "uuid": "^14.0.1"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-tooltip": "^5",
     "source-map-support": "^0.5",
     "usb": "^2.15",
-    "uuid": "^11.1.1"
+    "uuid": "^14.0.1"
   },
   "overrides": {
     "sockjs": {

--- a/src/Renderer/UartFiles/IS-uart.js
+++ b/src/Renderer/UartFiles/IS-uart.js
@@ -44,6 +44,18 @@ const TX_STEP = "S"; //Message to step one clock cycle
 const TX_READ = "R";  //Message to read viewer 0
 const TX_INTERVAL = 500;
 
+const encoder = new TextEncoder();
+
+//WebUSB transfers take a BufferSource, never a string. usb 2 hid this by
+//running the argument through Buffer.from, which encodes a string; usb 3
+//treats anything that is not an ArrayBuffer as an ArrayBufferView, so a
+//string silently becomes a zero-length transfer. Encode every message here.
+const msg = (s) => encoder.encode(s);
+
+//Likewise a control transfer with no payload: usb 2 substituted an empty
+//buffer for a missing argument, usb 3 dereferences it.
+const NO_DATA = new Uint8Array(0);
+
 var device
 var sendTimer
 var kill = false
@@ -68,12 +80,12 @@ function decimalToHex(d, padding) {
 export async function stepAndReadAllViewers(n){
     
     const release = await mutex.acquire();
-    await device.transferOut(TX_EP, TX_STEP);
+    await device.transferOut(TX_EP, msg(TX_STEP));
     //console.log("Step sent!");
     let viewerValues = [];
     for (var i=0;i<n;i++){
         let check = true;
-        await device.transferOut(TX_EP, TX_READ + decimalToHex(i,2));
+        await device.transferOut(TX_EP, msg(TX_READ + decimalToHex(i,2)));
         while(check){
             var result = await device.transferIn(RX_EP, RX_BUF_SIZE);
             if (result.data.byteLength > RX_PAD_BYTES) {
@@ -95,7 +107,7 @@ export async function readAllViewers(n){
     let viewerValues = [];
     for (var i=0;i<n;i++){
         let check = true;
-        await device.transferOut(TX_EP, TX_READ + decimalToHex(i,2));
+        await device.transferOut(TX_EP, msg(TX_READ + decimalToHex(i,2)));
         while(check){
             var result = await device.transferIn(RX_EP, RX_BUF_SIZE);
             if (result.data.byteLength > RX_PAD_BYTES) {
@@ -114,17 +126,17 @@ export async function readAllViewers(n){
 
 export async function step() {
     await mutex.waitForUnlock();
-    await device.transferOut(TX_EP, TX_STEP);
+    await device.transferOut(TX_EP, msg(TX_STEP));
     console.log("Step sent!");
 }
 
 export async function pauseOp() {
-    await device.transferOut(TX_EP, TX_PAUSE);
+    await device.transferOut(TX_EP, msg(TX_PAUSE));
     
 }
 
 export async function continuedOp() {
-    await device.transferOut(TX_EP, TX_CONTINUE);    
+    await device.transferOut(TX_EP, msg(TX_CONTINUE));    
 }
 
 
@@ -172,7 +184,7 @@ export async function connectAndRead(n) {
         request: BAUD_REQ,
         value: BAUD_VALUE,
         index: BAUD_INDEX,
-    });
+    }, NO_DATA);
 
     console.log(`Set baud = ${result.status}`);
 
@@ -220,7 +232,7 @@ export async function simpleConnect() {
         request: BAUD_REQ,
         value: BAUD_VALUE,
         index: BAUD_INDEX,
-    });
+    }, NO_DATA);
 
     console.log(`Set baud = ${result.status}`);
 


### PR DESCRIPTION
Closes the six open Dependabot PRs by applying the two that were real, explaining away the four that were not, and fixing the config that produced them.

## Why five of the six were unmergeable

`.github/dependabot.yml` targeted `dependabot-integration` for all three ecosystems. That branch is 119 commits behind `master` and its tip is `rollback: revert "Pull dependabot updates" (#632)`. Its `package.json` is still the 5.12.1 one — electron 35, react 17, plus `jest`/`eslint`/`enzyme` and an `npm` dependency that `master` has since dropped. So the updates were being computed against a manifest that no longer exists, and in two cases proposed versions **older** than what `master` already locked.

| PR | Outcome |
|---|---|
| #659 fast-uri 3.1.4→3.1.5 | Applied here |
| #653 uuid 11→14 | Applied here |
| #652 usb 2.15→3.0.1 | Applied here, with the source fix it needs |
| #655 mini-css-extract-plugin →2.10.2 | Closed — `master` already locks 2.10.2 |
| #656 terser-webpack-plugin →5.6.1 | Closed — `master` already locks 5.6.1 |
| #654 npm ^11→^12 | Closed — `npm` is not a dependency of Issie any more |

## Security

Two open high-severity advisories, both dev-only but both with a published fix, cleared by `npm audit fix`:

- **fast-uri 3.1.4 → 3.1.5** — GHSA-7p8r-x3mc-p8w7, host confusion via a backslash authority introducer. Reached through electron-builder → app-builder-lib → ajv.
- **brace-expansion 2.1.3 → 2.1.4 and 5.0.8 → 5.0.9** — GHSA-rgw5-rvv9-x895, DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. This is a *different* advisory from the over-matching one `.npmrc` describes, and unlike that one it is fixable in place, so the note there still stands.

The two open lodash alerts (#252, #254) are stale — the locked lodash is 4.18.1, dev-only, and audit reports nothing against it.

## uuid 11.1.1 → 14.0.1

Issie imports only `v4` (`DrawHelpers.fs:254`, `EEEHelpers.fs:148`), unchanged across 12/13/14. 13 made the browser exports the default and 14 requires a global `crypto` and node 20, both of which the renderer already has. Verified the production build resolves it through the `node` condition to `dist-node/rng.js` using `crypto.getRandomValues`, and that `v4` is in the emitted bundle.

`overrides.sockjs.uuid` deliberately stays at `^11.1.1`: uuid 14 is ESM-only (`"type": "module"`, no `main`) and sockjs reaches it through `require()`, so the two cannot share a copy. 11.1.1 is what cleared the advisory that override exists for.

## usb 2.18 → 3.0.1, and the fix it requires

usb 3 is a rewrite on rust `nusb` rather than libusb, dropping the legacy API for WebUSB alone. `IS-uart.js` already uses only WebUSB, so the surface survives — but two things it relied on were usb 2 conveniences, not WebUSB itself:

1. **Outgoing payloads are strings.** usb 2 ran them through `Buffer.from`, which encodes a string. usb 3 assumes anything that is not an `ArrayBuffer` is an `ArrayBufferView` and reads `.buffer`/`.byteOffset`/`.byteLength`, so a string yields `new Uint8Array(undefined, undefined, undefined)` — empty. Every command IS-uart.js sends is a string, so the stick would have received nothing while `transferOut` still reported `status: "ok"`, `bytesWritten: 0`.
2. **The baud-rate control transfers pass no payload.** usb 2 substituted an empty buffer; usb 3 dereferences the missing argument and throws.

Both fixed — commands go through `TextEncoder`, control transfers pass an explicit empty `Uint8Array`. Checked by driving usb 3's own prototype shims with the native calls stubbed: `"S"` arrives as `[83]` rather than `[]`, `"R0a"` as `[82,48,97]`, and the baud transfer returns `ok` instead of a `TypeError`.

Packaging changes too — ten per-platform `@node-usb/*` optional packages instead of one prebuild — but `usb` remains a webpack external, so the renderer bundle is unaffected.

## Testing

- `npm run build` (production webpack, main + renderer) succeeds
- `npm test` — 198 passed, 0 failed
- `npm audit` and `npm audit --omit=dev` both clean
- `usb` confirmed still external in `build/renderer-index.js`

**Not covered:** the libusb → nusb transport change against real hardware. The argument marshalling is proven correct, but an IceStick or IssieStick with an FT2232H should be run before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rUp4jYZF8cuEBzono1HzU