### PR TITLE
Open and create projects without the OS dialogs

### DIFF
--- a/Tests/Issie.Tests/PersistenceTests.fs
+++ b/Tests/Issie.Tests/PersistenceTests.fs
@@ -11,8 +11,67 @@ open CanvasBuilder
 let private sheetInfo: SheetInfo =
     { Form = Some User; Description = None; ParameterDefinitions = None; IsTopSheet = Some false }
 
+/// Run `body` against a fresh empty directory, which is removed afterwards.
+let private withTempDir (body: string -> unit) =
+    let folder =
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"issie-proj-{System.Guid.NewGuid()}")
+    System.IO.Directory.CreateDirectory folder |> ignore
+    try body folder
+    finally try System.IO.Directory.Delete(folder, true) with _ -> ()
+
+let private touch (folder: string) (name: string) =
+    System.IO.File.WriteAllText(System.IO.Path.Combine(folder, name), "")
+
 let tests =
     testList "Persistence" [
+
+        // What the New Project form asks of every keystroke, so that a name is refused while the
+        // user is still typing it rather than by an error box after the fact.
+        test "a project name is refused for exactly the characters it may not hold" {
+            let refused name =
+                Expect.isSome (FilesIO.projectNameError name) $"'{name}' should not be a project name"
+            let accepted name =
+                Expect.isNone (FilesIO.projectNameError name) $"'{name}' should be a project name"
+            accepted "adder"
+            accepted "Adder_4bit"
+            accepted "cpu2"
+            refused ""            // nothing typed is not a name, and Create must stay disabled
+            refused "my adder"    // spaces
+            refused "adder-4bit"  // hyphens: the message calls both out by name
+            refused "adder.dgm"
+            refused "../escape"
+        }
+
+        // A project is a directory, so opening one means judging a directory. Both the open path
+        // and the "would this new project be inside an existing one?" check read this.
+        test "a directory is told to be a project, sheets without a marker, or neither" {
+            withTempDir (fun folder ->
+                Expect.equal (FilesIO.inspectProjectDirectory folder) FilesIO.NotAProject
+                    "an empty folder holds no project"
+
+                touch folder "main.dgm"
+                Expect.equal (FilesIO.inspectProjectDirectory folder) FilesIO.SheetsButNoMarker
+                    "sheets alone are loadable, but nothing says the folder is a project"
+
+                touch folder (System.IO.Path.GetFileName folder + ".dprj")
+                Expect.equal (FilesIO.inspectProjectDirectory folder) FilesIO.IsProject
+                    "the marker is what makes it a project")
+        }
+
+        test "a folder holding only the marker still counts as a project" {
+            // an emptied project is still a project: it has a marker, and Issie must not offer to
+            // create another one inside it
+            withTempDir (fun folder ->
+                touch folder "anything.dprj"
+                Expect.equal (FilesIO.inspectProjectDirectory folder) FilesIO.IsProject
+                    "the marker alone is enough")
+        }
+
+        test "a project's marker is named after its folder" {
+            let path = FilesIO.projectMarkerPath (FilesIO.pathJoin [| "some"; "where"; "adder" |])
+            Expect.equal (FilesIO.baseName path) "adder.dprj" "the marker takes the folder's name"
+        }
+
         test "stateToJsonString round-trips a canvas through jsonStringToState" {
             let inComp = makeComp "in0" 0 1 (Input1(3, None)) "I0"
             let dut = makeComp "not" 1 1 (NbitsNot 3) "N1"

--- a/Tests/Issie.Tests/PersistenceTests.fs
+++ b/Tests/Issie.Tests/PersistenceTests.fs
@@ -67,6 +67,37 @@ let tests =
                     "the marker alone is enough")
         }
 
+        // A folder picker draws every folder alike, so the folder somebody chooses is as likely to
+        // be the one their projects live in as a project. This is what turns that near miss into
+        // the list of projects to pick from, rather than a refusal.
+        test "the projects inside a folder are found, and nothing else is" {
+            withTempDir (fun folder ->
+                let sub name =
+                    let p = System.IO.Path.Combine(folder, name)
+                    System.IO.Directory.CreateDirectory p |> ignore
+                    p
+                let marked = sub "adder"
+                touch marked "adder.dprj"
+                touch marked "main.dgm"
+                let unmarked = sub "orphan"
+                touch unmarked "main.dgm"
+                sub "notes" |> ignore                   // an ordinary folder
+                touch (sub "empty") ".keep"             // a folder with nothing Issie wants
+                touch folder "loose.dgm"                // a file, not a folder, and not recursed into
+
+                let found = FilesIO.projectsWithin folder
+                Expect.equal (found |> List.map (fst >> System.IO.Path.GetFileName)) ["adder"; "orphan"]
+                    "both openable folders are offered, in name order, and nothing else is"
+                Expect.equal (found |> List.map snd) [FilesIO.IsProject; FilesIO.SheetsButNoMarker]
+                    "and each is labelled with what it is, since one of them lacks its marker")
+        }
+
+        test "a folder with nothing openable inside offers nothing" {
+            withTempDir (fun folder ->
+                System.IO.Directory.CreateDirectory(System.IO.Path.Combine(folder, "notes")) |> ignore
+                Expect.isEmpty (FilesIO.projectsWithin folder) "an ordinary folder is not offered")
+        }
+
         test "a project's marker is named after its folder" {
             let path = FilesIO.projectMarkerPath (FilesIO.pathJoin [| "some"; "where"; "adder" |])
             Expect.equal (FilesIO.baseName path) "adder.dprj" "the marker takes the folder's name"

--- a/Tests/Issie.Tests/PersistenceTests.fs
+++ b/Tests/Issie.Tests/PersistenceTests.fs
@@ -67,35 +67,47 @@ let tests =
                     "the marker alone is enough")
         }
 
-        // A folder picker draws every folder alike, so the folder somebody chooses is as likely to
-        // be the one their projects live in as a project. This is what turns that near miss into
-        // the list of projects to pick from, rather than a refusal.
-        test "the projects inside a folder are found, and nothing else is" {
+        // What the project browser draws. A native folder picker cannot say which folders are
+        // projects, which is the whole reason Issie lists them itself.
+        test "a folder is listed with what each thing in it is, projects first" {
             withTempDir (fun folder ->
                 let sub name =
                     let p = System.IO.Path.Combine(folder, name)
                     System.IO.Directory.CreateDirectory p |> ignore
                     p
-                let marked = sub "adder"
-                touch marked "adder.dprj"
+                let marked = sub "zebra"                // named last, to prove projects sort first
+                touch marked "zebra.dprj"
                 touch marked "main.dgm"
+                touch marked "alu.dgm"
                 let unmarked = sub "orphan"
                 touch unmarked "main.dgm"
-                sub "notes" |> ignore                   // an ordinary folder
-                touch (sub "empty") ".keep"             // a folder with nothing Issie wants
-                touch folder "loose.dgm"                // a file, not a folder, and not recursed into
+                sub "notes" |> ignore                   // an ordinary folder: navigable, so listed
+                sub ".hidden" |> ignore                 // hidden: nobody keeps projects there
+                touch folder "loose.dgm"                // a file, so not a folder in the listing
 
-                let found = FilesIO.projectsWithin folder
-                Expect.equal (found |> List.map (fst >> System.IO.Path.GetFileName)) ["adder"; "orphan"]
-                    "both openable folders are offered, in name order, and nothing else is"
-                Expect.equal (found |> List.map snd) [FilesIO.IsProject; FilesIO.SheetsButNoMarker]
-                    "and each is labelled with what it is, since one of them lacks its marker")
+                let listed = FilesIO.listFolderForOpening folder
+                Expect.equal (listed |> List.map (fun e -> System.IO.Path.GetFileName e.Path))
+                    ["orphan"; "zebra"; "notes"]
+                    "openable folders first in name order, then ordinary ones; hidden and files omitted"
+                Expect.equal (listed |> List.map (fun e -> e.Kind))
+                    [FilesIO.SheetsButNoMarker; FilesIO.IsProject; FilesIO.NotAProject]
+                    "each says what it is, so the browser can mark it"
+                Expect.equal (listed |> List.map (fun e -> e.SheetCount)) [1; 2; 0]
+                    "and how many sheets it holds, which is what tells two projects apart")
         }
 
-        test "a folder with nothing openable inside offers nothing" {
+        test "a folder holding nothing lists nothing" {
             withTempDir (fun folder ->
-                System.IO.Directory.CreateDirectory(System.IO.Path.Combine(folder, "notes")) |> ignore
-                Expect.isEmpty (FilesIO.projectsWithin folder) "an ordinary folder is not offered")
+                Expect.isEmpty (FilesIO.listFolderForOpening folder) "an empty folder lists nothing")
+        }
+
+        test "a path that is not a folder lists nothing rather than failing" {
+            withTempDir (fun folder ->
+                touch folder "a.dgm"
+                let notAFolder = System.IO.Path.Combine(folder, "a.dgm")
+                Expect.isEmpty (FilesIO.listFolderForOpening notAFolder) "a file has nothing inside it"
+                Expect.isEmpty (FilesIO.listFolderForOpening (System.IO.Path.Combine(folder, "nope")))
+                    "nor does a path that is not there")
         }
 
         test "a project's marker is named after its folder" {

--- a/src/Main/Main.fs
+++ b/src/Main/Main.fs
@@ -168,7 +168,20 @@ let createMainWindow () =
     // This method will be called when Electron has finished
     // initialization and is ready to create browser windows.
 let startRenderer (doAfterReady: BrowserWindow -> Unit) =
-    mainProcess.app.on_ready(fun _ _ -> 
+    mainProcess.app.on_ready(fun _ _ ->
+        // Issie has no application menu: every key it cares about is resolved by KeyBindings
+        // against the context the user is in, and an Electron menu registers its accelerators
+        // globally and unconditionally. Clearing it HERE, before the first window exists, is what
+        // makes that true - Electron installs its own File/Edit/View/Window/Help menu otherwise,
+        // and a window created with autoHideMenuBar false shows it.
+        //
+        // The renderer used to be left to remove it, by assigning app.applicationMenu across the
+        // @electron/remote bridge from inside an Elmish subscription. That is both late - the
+        // standard menus are up for as long as the renderer takes to load - and conditional on a
+        // remote property assignment landing at all. When it did not, they simply stayed. A debug
+        // build still adds its Development menu from the renderer afterwards, which is where it
+        // has to be built since its items dispatch into the app.
+        mainProcess.Menu.setApplicationMenu None
         let window = createMainWindow()
         //printfn "window created"
         window

--- a/src/Renderer/Common/KeyTypes.fs
+++ b/src/Renderer/Common/KeyTypes.fs
@@ -307,14 +307,19 @@ let shortcuts: ShortcutSpec list =
       // ------------------------------------------------------------------ project browser
       // Only in its own context, so no other dialog sees them. Arrows repeat, since holding one
       // to run down a long folder is the point; opening and going up do not.
+      //
+      // No Doc, which keeps them out of the shortcut table. That table is what a user consults
+      // while drawing, and these four exist only inside one dialog, which says what they do on
+      // its own face - listing them there would be four rows of noise between the keys that do
+      // apply to the schematic.
       repeating (spec ScBrowserPrev (both [ ch Mods.none (named Names.arrowUp) ]) [ ProjectBrowser ]
-          "Previous folder in the list" CatView)
+          "" CatView)
       repeating (spec ScBrowserNext (both [ ch Mods.none (named Names.arrowDown) ]) [ ProjectBrowser ]
-          "Next folder in the list" CatView)
+          "" CatView)
       spec ScBrowserOpen (both [ ch Mods.none (named Names.enter) ]) [ ProjectBrowser ]
-          "Open the selected project, or go into the selected folder" CatView
+          "" CatView
       spec ScBrowserParent (both [ ch Mods.none (named Names.backspace) ]) [ ProjectBrowser ]
-          "Go up to the containing folder" CatView
+          "" CatView
       spec ScDeselect (both [ ch Mods.none (named Names.escape) ]) [ SheetIdle ]
           "Deselect everything" CatEdit
       spec ScLeaveTextBox

--- a/src/Renderer/Common/KeyTypes.fs
+++ b/src/Renderer/Common/KeyTypes.fs
@@ -81,6 +81,9 @@ type KeyContext =
     | TextEntry
     /// the hand-rolled code editor is up
     | CodeEditor
+    /// the project browser is showing and focus is not in its path box. Its own context rather
+    /// than Popup, because arrows and Enter mean something there and nothing in any other dialog
+    | ProjectBrowser
     /// a modal popup is showing and focus is not in one of its boxes
     | Popup
     /// the waveform simulator has the keyboard
@@ -118,6 +121,11 @@ type ShortcutId =
     // ---- escape, one identity per context ----
     | ScCancelGesture
     | ScClosePopup
+    // ---- project browser ----
+    | ScBrowserPrev
+    | ScBrowserNext
+    | ScBrowserOpen
+    | ScBrowserParent
     | ScDeselect
     | ScLeaveTextBox
     // ---- view ----
@@ -293,8 +301,20 @@ let shortcuts: ShortcutSpec list =
       // ------------------------------------------------------------------ escape, by context
       spec ScCancelGesture (both [ ch Mods.none (named Names.escape) ]) [ SheetBusy ]
           "Cancel the action in progress" CatEdit
-      spec ScClosePopup (both [ ch Mods.none (named Names.escape) ]) [ Popup ]
+      spec ScClosePopup (both [ ch Mods.none (named Names.escape) ]) [ Popup; ProjectBrowser ]
           "Close the open dialogue" CatEdit
+
+      // ------------------------------------------------------------------ project browser
+      // Only in its own context, so no other dialog sees them. Arrows repeat, since holding one
+      // to run down a long folder is the point; opening and going up do not.
+      repeating (spec ScBrowserPrev (both [ ch Mods.none (named Names.arrowUp) ]) [ ProjectBrowser ]
+          "Previous folder in the list" CatView)
+      repeating (spec ScBrowserNext (both [ ch Mods.none (named Names.arrowDown) ]) [ ProjectBrowser ]
+          "Next folder in the list" CatView)
+      spec ScBrowserOpen (both [ ch Mods.none (named Names.enter) ]) [ ProjectBrowser ]
+          "Open the selected project, or go into the selected folder" CatView
+      spec ScBrowserParent (both [ ch Mods.none (named Names.backspace) ]) [ ProjectBrowser ]
+          "Go up to the containing folder" CatView
       spec ScDeselect (both [ ch Mods.none (named Names.escape) ]) [ SheetIdle ]
           "Deselect everything" CatEdit
       spec ScLeaveTextBox

--- a/src/Renderer/DrawBlock/SheetLayout.fs
+++ b/src/Renderer/DrawBlock/SheetLayout.fs
@@ -620,12 +620,12 @@ let saveLibraryComponent
         |> Result.bind (fun () -> write true sheet))
 
 /// Write a whole project: every sheet, plus the empty .dprj marker that makes the directory a
-/// project rather than a directory that happens to contain sheets. Issie will not offer a
-/// directory without one, and drops it from the recent list.
+/// project rather than a directory that happens to contain sheets. Issie will open a directory
+/// without one, offering to put it back, but only a marked directory is recognised as a project
+/// without being asked about.
 let saveProject (folder: string) (sheets: SheetDescription list) : Result<unit, string> =
     match FilesIO.tryEnsureDirectory folder with
     | Error msg -> Error msg
     | Ok folder ->
-        let marker = FilesIO.pathJoin [| folder; FilesIO.baseName folder + ".dprj" |]
-        FilesIO.writeFile marker ""
+        FilesIO.writeFile (FilesIO.projectMarkerPath folder) ""
         |> Result.bind (fun () -> sheets |> Helpers.ResultList.iter (saveSheet folder))

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -348,28 +348,49 @@ type ProjectDirectory =
     /// Nothing here that Issie can open.
     | NotAProject
 
-let inspectProjectDirectory (path: string) : ProjectDirectory =
+/// What a directory is to Issie, and how many sheets are in it, from the one read of it. The
+/// count is free once the classification has looked at the file names anyway.
+let inspectFolder (path: string) : ProjectDirectory * int =
     let files = readFilesFromDirectory path
-    match files |> List.exists (hasExtn ".dprj"), files |> List.exists (hasExtn ".dgm") with
-    | true, _ -> IsProject
-    | false, true -> SheetsButNoMarker
-    | false, false -> NotAProject
+    let sheets = files |> List.filter (hasExtn ".dgm") |> List.length
+    match files |> List.exists (hasExtn ".dprj"), sheets > 0 with
+    | true, _ -> IsProject, sheets
+    | false, true -> SheetsButNoMarker, sheets
+    | false, false -> NotAProject, sheets
+
+let inspectProjectDirectory (path: string) : ProjectDirectory = inspectFolder path |> fst
 
 /// The empty file that marks a directory as an Issie project, named after the directory.
 let projectMarkerPath (projectPath: string) =
     pathJoin [| projectPath; baseName projectPath + ".dprj" |]
 
-/// The immediate subdirectories of `path` that Issie could open, and what each of them is.
+/// True when a path has no parent to go up to - a drive root, or the root of a share. dirName
+/// returns such a path unchanged, which is what the browser's Up control asks.
+let isFilesystemRoot (path: string) = dirName path = path
+
+/// One folder as the project browser draws it.
+type FolderEntry = {
+    Path: string
+    Kind: ProjectDirectory
+    /// .dgm files directly inside it: what a project is worth telling apart by, without opening it.
+    SheetCount: int
+}
+
+/// Every immediate subdirectory of `path`, classified, for the browser to draw.
 ///
-/// A folder picker shows every folder alike, so the folder somebody browses to is as likely to be
-/// the one their projects live in as a project itself. This is what lets that be answered with the
-/// projects rather than with a refusal. One level only: it answers "you have picked the folder
-/// your projects are in", not "search my disk".
-let projectsWithin (path: string) : (string * ProjectDirectory) list =
+/// A native folder picker draws every folder alike, so it cannot show which of them hold projects -
+/// which is the whole reason Issie draws this list itself. Ordinary folders are included because
+/// the browser navigates into them; hidden ones are not, since nobody keeps projects in them and
+/// they would bury what is worth seeing. Openable folders sort first, so a project is never lost
+/// among unrelated ones. One level only: this lists a folder, it does not search a disk.
+let listFolderForOpening (path: string) : FolderEntry list =
     readSubdirectories path
-    |> List.map (fun dir -> dir, inspectProjectDirectory dir)
-    |> List.filter (fun (_, kind) -> kind <> NotAProject)
-    |> List.sortBy fst
+    |> List.filter (fun dir -> not ((baseName dir).StartsWith "."))
+    |> List.map (fun dir ->
+        let kind, sheets = inspectFolder dir
+        { Path = dir; Kind = kind; SheetCount = sheets })
+    |> List.sortBy (fun entry ->
+        (match entry.Kind with NotAProject -> 1 | _ -> 0), String.toLower (baseName entry.Path))
 
 let removeExtn extn fName = 
     if hasExtn extn fName

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -297,22 +297,34 @@ let readFilesFromDirectory (path:string) : string list =
         printf $"Warning: readFilesFromDirectory has 'path'='{path}' and this directory does not exist."
         []
 
+#if FABLE_COMPILER
+/// readdirSync asked for Dirent entries, which each say whether they are a directory, and reduced
+/// to the names of those that are. One call, no stat of anything.
+[<Emit("$0.readdirSync($1, { withFileTypes: true }).filter(e => e.isDirectory()).map(e => e.name)")>]
+let private subdirectoryNamesOf (fsModule: obj) (folderPath: string) : string array = jsNative
+#endif
+
 /// The immediate subdirectories of a folder, as full paths. [] if it cannot be read.
 ///
 /// Deliberately not readdir: under .NET that is Directory.GetFiles, which lists files only, while
 /// node's readdirSync lists directories too. Anything looking for subfolders through readdir
 /// therefore works in the app and finds nothing under test - which is how this function came to
 /// exist.
+///
+/// The directories come from the one readdir rather than from a stat of each entry, which is what
+/// this used to do: existsSync and lstatSync per name, paid on every FILE in the folder before
+/// discarding it. Listing C:\Windows\System32 took 244ms that way and takes 3ms this way - 4,885
+/// entries, of which 4,687 were files answering a question nobody asked. Directory.GetDirectories
+/// never had the problem, so only the node side changes.
 let readSubdirectories (folderPath: string) : string list =
     if not (isDirectory folderPath) then
         []
     else
         try
             #if FABLE_COMPILER
-            fs.readdirSync (U2.Case1 folderPath)
-            |> Seq.toList
+            subdirectoryNamesOf fs folderPath
+            |> Array.toList
             |> List.map (fun name -> pathJoin [| folderPath; name |])
-            |> List.filter isDirectory
             #else
             Directory.GetDirectories folderPath |> Array.toList
             #endif

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -297,6 +297,29 @@ let readFilesFromDirectory (path:string) : string list =
         printf $"Warning: readFilesFromDirectory has 'path'='{path}' and this directory does not exist."
         []
 
+/// The immediate subdirectories of a folder, as full paths. [] if it cannot be read.
+///
+/// Deliberately not readdir: under .NET that is Directory.GetFiles, which lists files only, while
+/// node's readdirSync lists directories too. Anything looking for subfolders through readdir
+/// therefore works in the app and finds nothing under test - which is how this function came to
+/// exist.
+let readSubdirectories (folderPath: string) : string list =
+    if not (isDirectory folderPath) then
+        []
+    else
+        try
+            #if FABLE_COMPILER
+            fs.readdirSync (U2.Case1 folderPath)
+            |> Seq.toList
+            |> List.map (fun name -> pathJoin [| folderPath; name |])
+            |> List.filter isDirectory
+            #else
+            Directory.GetDirectories folderPath |> Array.toList
+            #endif
+        with e ->
+            printf $"Warning: readSubdirectories failed on '{folderPath}': {e.Message}"
+            []
+
 let hasExtn extn fName =
     (String.toLower fName).EndsWith (String.toLower extn)
 
@@ -335,6 +358,18 @@ let inspectProjectDirectory (path: string) : ProjectDirectory =
 /// The empty file that marks a directory as an Issie project, named after the directory.
 let projectMarkerPath (projectPath: string) =
     pathJoin [| projectPath; baseName projectPath + ".dprj" |]
+
+/// The immediate subdirectories of `path` that Issie could open, and what each of them is.
+///
+/// A folder picker shows every folder alike, so the folder somebody browses to is as likely to be
+/// the one their projects live in as a project itself. This is what lets that be answered with the
+/// projects rather than with a refusal. One level only: it answers "you have picked the folder
+/// your projects are in", not "search my disk".
+let projectsWithin (path: string) : (string * ProjectDirectory) list =
+    readSubdirectories path
+    |> List.map (fun dir -> dir, inspectProjectDirectory dir)
+    |> List.filter (fun (_, kind) -> kind <> NotAProject)
+    |> List.sortBy fst
 
 let removeExtn extn fName = 
     if hasExtn extn fName
@@ -450,8 +485,10 @@ let private makeFileFilters (name : string) (extn : string) =
 /// impossible even though loading a project never reads it.
 let askForExistingProjectPath (defaultPath: string option) : string option =
     let options = createEmpty<OpenDialogSyncOptions>
-    options.title <- Some "Open ISSIE project folder"
-    options.buttonLabel <- Some "Open project"
+    // A folder picker draws every folder the same, so it cannot show which ones hold projects.
+    // The title says that the folder they are in will do, which is what Issie then acts on.
+    options.title <- Some "Choose an ISSIE project folder, or a folder containing projects"
+    options.buttonLabel <- Some "Open"
     options.properties <- Some [| OpenDialogOptionsPropertiesArray.OpenDirectory |]
     options.defaultPath <-
         defaultPath

--- a/src/Renderer/Interface/FilesIO.fs
+++ b/src/Renderer/Interface/FilesIO.fs
@@ -311,6 +311,31 @@ let readFilesFromDirectoryWithExtn (path:string) (extn:string) : string list =
     readFilesFromDirectory path
     |> List.filter (fun name -> hasExtn extn name)
 
+/// What a directory looks like to Issie.
+///
+/// The .dprj marker is not needed to load a project - loadAllComponentFiles reads the .dgm files
+/// and never opens it - but it is how a project is told from a folder that merely happens to have
+/// sheets in it, and how "would this new project be inside an existing one?" is answered.
+type ProjectDirectory =
+    /// Holds the marker: a project, whatever else is in it.
+    | IsProject
+    /// Holds sheets but no marker, so it was a project whose marker has been lost, or a folder
+    /// somebody put sheets in. Loadable either way.
+    | SheetsButNoMarker
+    /// Nothing here that Issie can open.
+    | NotAProject
+
+let inspectProjectDirectory (path: string) : ProjectDirectory =
+    let files = readFilesFromDirectory path
+    match files |> List.exists (hasExtn ".dprj"), files |> List.exists (hasExtn ".dgm") with
+    | true, _ -> IsProject
+    | false, true -> SheetsButNoMarker
+    | false, false -> NotAProject
+
+/// The empty file that marks a directory as an Issie project, named after the directory.
+let projectMarkerPath (projectPath: string) =
+    pathJoin [| projectPath; baseName projectPath + ".dprj" |]
+
 let removeExtn extn fName = 
     if hasExtn extn fName
     then Some fName[0..(fName.Length - extn.Length - 1)]
@@ -414,12 +439,20 @@ let private makeFileFilters (name : string) (extn : string) =
     |> unbox<FileFilter> 
     |> Array.singleton
 
-/// Ask the user to choose a project file, with a dialog window.
-/// Return the folder containing the chosen project file.
-/// Return None if the user exits withouth selecting a path.
+/// Ask the user to choose a project, with a dialog window.
+/// Return the chosen folder, or None if the user exits without choosing one.
+///
+/// A project IS a directory, so that is what the dialog asks for. It used to ask for the .dprj
+/// inside one, which meant navigating into the project, past its sheets greyed out by the filter,
+/// to select a file that is empty, says nothing, and is named after the folder the user was
+/// already standing in - and whose directory was then all that was kept. Asking for the folder
+/// also lets a project whose marker was lost or renamed be opened, which the filter made
+/// impossible even though loading a project never reads it.
 let askForExistingProjectPath (defaultPath: string option) : string option =
     let options = createEmpty<OpenDialogSyncOptions>
-    options.filters <- Some (makeFileFilters "ISSIE project file" "dprj" |> ResizeArray)
+    options.title <- Some "Open ISSIE project folder"
+    options.buttonLabel <- Some "Open project"
+    options.properties <- Some [| OpenDialogOptionsPropertiesArray.OpenDirectory |]
     options.defaultPath <-
         defaultPath
         |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
@@ -430,8 +463,26 @@ let askForExistingProjectPath (defaultPath: string option) : string option =
         Seq.toList
         >> function
         | [] -> Option.None
-        | p :: _ -> Some <| dirName p
+        | p :: _ -> Some p
     )
+
+/// Ask the user to choose a folder, for a caller that knows what it wants one for.
+/// Return None if the user exits without choosing one.
+let askForFolder (title: string) (buttonLabel: string) (defaultPath: string option) : string option =
+    let options = createEmpty<OpenDialogSyncOptions>
+    options.title <- Some title
+    options.buttonLabel <- Some buttonLabel
+    options.properties <- Some [|
+        OpenDialogOptionsPropertiesArray.OpenDirectory
+        OpenDialogOptionsPropertiesArray.CreateDirectory
+        |]
+    options.defaultPath <-
+        defaultPath
+        |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
+        |> Some
+    let w = electronRemote.getCurrentWindow()
+    electronRemote.dialog.showOpenDialogSync(w,options)
+    |> Option.bind (Seq.toList >> function [] -> Option.None | p :: _ -> Some p)
 
 /// ask for existing sheet paths
 let askForExistingSheetPaths (defaultPath: string option) : string list option =
@@ -456,44 +507,29 @@ let askForExistingSheetPaths (defaultPath: string option) : string list option =
 
 
 
-/// Ask the user a new project path, with a dialog window.
-/// Return None if the user exits withouth selecting a path.
-let rec askForNewProjectPath (defaultPath:string option) : string option =
-    let options = createEmpty<SaveDialogSyncOptions>
-    options.filters <- Some (makeFileFilters "ISSIE project" "" |> ResizeArray)
-    options.title <- Some "Enter new ISSIE project directory and name"
-    options.nameFieldLabel <- Some "New project name"
-    options.defaultPath <- defaultPath
-    options.buttonLabel <- Some "Create Project"
-    options.properties <- Some [|
-        SaveDialogOptionsPropertiesArray.CreateDirectory
-        SaveDialogOptionsPropertiesArray.ShowOverwriteConfirmation
-        |]
-    match electronRemote.getCurrentWindow() with
-    | w ->
-        electronRemote.dialog.showSaveDialogSync(options)
-        |> Option.bind (fun dPath ->
-            let dir = dirName dPath
-            let files = readdir dir
-            if Seq.exists (fun (fn:string) -> fn.EndsWith ".dprj") files
-            then
-                electronRemote.dialog.showErrorBox(
-                    "Invalid project directory",
-                    "You are trying to create a new Issie project inside an existing project directory. \
-                     This is not allowed, please choose a different directory")
-                askForNewProjectPath defaultPath
-            
-            else
-                Some dPath)
-    
-    
+// askForNewProjectPath, a native SAVE dialog that asked the user to save a file which was really
+// a directory, is gone: FileUpdate.newProject asks for the name and the folder in the app, where
+// the naming rule and the inside-an-existing-project rule can be answered while the user is still
+// typing rather than by an error box after the dialog has taken their typing away.
 
-
-    
-let tryCreateFolder (path : string) =
-    if Seq.exists (Char.IsLetterOrDigitOrUnderscore >> not) (baseName path) then 
-        Result.Error <| "Project names must contain only letters, digits, or underscores. Spaces and hyphens are not allowed."
+/// Why a project may not be called this, if it may not.
+///
+/// One rule, in one place: the creation form asks it of every keystroke so that the user sees the
+/// objection while they can still act on it, and tryCreateFolder asks it as the last word. It used
+/// to be reachable only by breaking it, after the native dialog had been dismissed, in an error
+/// box that took the typing with it.
+let projectNameError (name: string) : string option =
+    if name = "" then
+        Some "Enter a name for the project."
+    elif Seq.exists (Char.IsLetterOrDigitOrUnderscore >> not) name then
+        Some "Project names must contain only letters, digits, or underscores. Spaces and hyphens are not allowed."
     else
+        None
+
+let tryCreateFolder (path : string) =
+    match projectNameError (baseName path) with
+    | Some err -> Result.Error err
+    | None ->
         try
             Result.Ok <| mkdir path
         with

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -587,6 +587,14 @@ type Msg =
     /// A second has passed: read the browsed folder again, and come back in another second.
     /// Does nothing once the browser has closed, which is what ends the chain.
     | TickProjectBrowser
+    /// Move the project browser's keyboard selection by this many rows.
+    | MoveProjectBrowserSelection of int
+    /// Show the folder containing the one being browsed. Does nothing at a filesystem root.
+    | GoToProjectBrowserParent
+    /// Act on the selected row: a project opens, an ordinary folder is entered. Carries dispatch
+    /// as FileCommand does, because opening a project is not something the update function can do
+    /// with a message alone.
+    | OpenProjectBrowserSelection of (Msg -> unit)
     | ChangeBuildTabVisibility
     /// Set width of right-hand pane when tab is WaveSimulator or TruthTable
     | SetViewerWidth of int
@@ -749,10 +757,16 @@ type DragPlacement =
 type ProjectBrowserState = {
     /// The folder being shown.
     Folder: string
-    /// Bumped once a second. The listing is memoised - reading a directory is a disk access and a
-    /// popup body runs on every message - so this is what tells it to look at the disk again, and
-    /// what keeps typing in the path field from listing every prefix along the way.
-    Generation: int
+    /// What is in it, or why it cannot be shown.
+    ///
+    /// Read when the folder changes and once a second after that, in the update function rather
+    /// than while rendering. A popup body runs on every message, so a view that read the disk
+    /// would read it continuously - and the keyboard has to know how many rows there are before
+    /// it can move between them.
+    Listing: Result<FilesIO.FolderEntry list, string>
+    /// The row the keyboard is on, an index into the listing. Clamped whenever the listing changes,
+    /// since the folder can grow or shrink underneath it.
+    Selected: int
 }
 
 /// Which half of the window the keyboard is pointing at.

--- a/src/Renderer/Model/ModelType.fs
+++ b/src/Renderer/Model/ModelType.fs
@@ -582,6 +582,11 @@ type Msg =
     /// Stop carrying a catalogue item, whether because it was dropped somewhere that places
     /// nothing or because the placement it started has now been made.
     | EndDragPlacement
+    /// Show this folder in the project browser, opening the browser if it is not already open.
+    | SetProjectBrowserFolder of string
+    /// A second has passed: read the browsed folder again, and come back in another second.
+    /// Does nothing once the browser has closed, which is what ends the chain.
+    | TickProjectBrowser
     | ChangeBuildTabVisibility
     /// Set width of right-hand pane when tab is WaveSimulator or TruthTable
     | SetViewerWidth of int
@@ -736,6 +741,20 @@ type DragPlacement =
     /// stands between the drop and the component existing.
     | DroppedAt of XYPos
 
+/// The project browser's state while it is open.
+///
+/// Its own field rather than borrowed dialog text: the refresh timer has to be able to ask whether
+/// the browser is still open, and a timer that answered from shared popup state would go on
+/// writing into whatever dialog opened next.
+type ProjectBrowserState = {
+    /// The folder being shown.
+    Folder: string
+    /// Bumped once a second. The listing is memoised - reading a directory is a disk access and a
+    /// popup body runs on every message - so this is what tells it to look at the disk again, and
+    /// what keeps typing in the path field from listing every prefix along the way.
+    Generation: int
+}
+
 /// Which half of the window the keyboard is pointing at.
 type Pane = | LeftPane | RightPane
 
@@ -808,6 +827,9 @@ type Model = {
     /// A catalogue item being dragged onto the canvas, or the position one was dropped at. None
     /// whenever no such gesture is in flight, which is nearly always.
     DragPlacement : DragPlacement option
+    /// Set while the project browser is open, and None the rest of the time - which is how its
+    /// refresh timer knows to stop.
+    ProjectBrowser : ProjectBrowserState option
     /// Projects whose top-sheet choice popup the user has cancelled. Cancelling opens the sheet
     /// at default parameter values; the question is not asked again for that project.
     TopSheetChoiceDeclined : Set<string>
@@ -879,6 +901,7 @@ let uISheetTrail_ = Lens.create (fun a -> a.UISheetTrail) (fun s a -> {a with UI
 let savedSheetIsOutOfDate_ = Lens.create (fun a -> a.SavedSheetIsOutOfDate) (fun s a -> {a with SavedSheetIsOutOfDate = s})
 let pendingDragAddition_ = Lens.create (fun a -> a.PendingDragAddition) (fun s a -> {a with PendingDragAddition = s})
 let dragPlacement_ = Lens.create (fun a -> a.DragPlacement) (fun s a -> {a with DragPlacement = s})
+let projectBrowser_ = Lens.create (fun a -> a.ProjectBrowser) (fun s a -> {a with ProjectBrowser = s})
 let topSheetChoiceDeclined_ = Lens.create (fun a -> a.TopSheetChoiceDeclined) (fun s a -> {a with TopSheetChoiceDeclined = s})
 let openLibrary_ = Lens.create (fun a -> a.OpenLibrary) (fun s a -> {a with OpenLibrary = s})
 let showLibrarySheets_ = Lens.create (fun a -> a.ShowLibrarySheets) (fun s a -> {a with ShowLibrarySheets = s})

--- a/src/Renderer/Renderer.fs
+++ b/src/Renderer/Renderer.fs
@@ -279,12 +279,16 @@ let attachMenusAndKeyShortcuts (dispatch: Msg -> unit) : System.IDisposable =
     dispatch
     <| Msg.ExecFuncInMessage(
         (fun _ _ ->
-            // None removes the menu bar entirely on Windows and Linux. Every key it used to
-            // register is now resolved by KeyBindings against the context the user is in.
-            electronRemote.app.applicationMenu <-
-                match template with
-                | [] -> None
-                | items ->
+            // Only ever ADDS a menu, and only a debug build has one to add. Removing the menu bar
+            // is the main process's job, done before the first window exists (Main.startRenderer):
+            // doing it from here left Electron's own File/Edit/View/Window/Help menu up until the
+            // renderer had loaded, and left it up for good whenever this assignment - a property
+            // set across the @electron/remote bridge - did not land. Every key those menus used to
+            // register is resolved by KeyBindings against the context the user is in.
+            match template with
+            | [] -> ()
+            | items ->
+                electronRemote.app.applicationMenu <-
                     items
                     |> List.map U2.Case1
                     |> Array.ofList

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -179,10 +179,11 @@ let private newProject model dispatch =
 
     
 
-/// The browser's state, or an empty one. The popup only renders while it is Some.
-let private browserState (model: Model) =
-    model.ProjectBrowser
-    |> Option.defaultValue { Folder = ""; Listing = Ok []; Selected = 0 }
+// browserState, which supplied an empty state when the model had none, is gone. Its fallback
+// listing was Ok [], which renders as "Nothing in this folder" - so any moment the popup drew
+// before or after its state existed claimed the folder was empty, over a folder full of projects.
+// The body matches on the state instead and draws nothing without it, so that message can only
+// ever come from having actually read an empty folder.
 
 /// The path as clickable segments, so that going up several levels is one click rather than
 /// several - which is what the Up button alone made it. Explorer's address bar does the same, and
@@ -192,13 +193,27 @@ let private breadcrumbOf (folder: string) (goTo: string -> unit) =
     // than a reassembled one - separators differ between platforms and a rebuilt root is wrong
     let rec ancestors (path: string) =
         if isFilesystemRoot path then [path] else ancestors (dirName path) @ [path]
-    Breadcrumb.breadcrumb [Breadcrumb.Size IsSmall] [
-        for path in ancestors folder ->
-            Breadcrumb.item [] [
-                a [ OnClick (fun _ -> goTo path); HTMLAttr.Title path ]
-                  [str (if isFilesystemRoot path then path else baseName path)]
-            ]
-    ]
+    /// A root reads as "C:" rather than "C:\": the crumb separator already does the work the
+    /// trailing slash would, and showing both puts the OS separator and the UI one side by side.
+    /// A POSIX root is "/" and has nothing left once its separator is taken away, so it keeps it.
+    let label (path: string) =
+        if not (isFilesystemRoot path) then
+            baseName path
+        else
+            match path.TrimEnd [| '\\'; '/' |] with
+            | "" -> path
+            | trimmed -> trimmed
+    div [Style [ Display DisplayOptions.Flex; FlexWrap "wrap"
+                 AlignItems AlignItemsOptions.Center; MarginBottom "6px" ]]
+        (ancestors folder
+         |> List.indexed
+         |> List.collect (fun (i, path) ->
+             [ // "›", not a slash: it is what Explorer's own address bar separates with, it is
+               // what the rows below use to mean "go in", and unlike "/" it claims nothing about
+               // which separator this platform uses
+               if i > 0 then
+                   span [Style [Color "grey"; Margin "0 5px"]] [str "›"]
+               a [OnClick (fun _ -> goTo path); HTMLAttr.Title path] [str (label path)] ]))
 
 /// Open the folder the user chose, which may not be a project.
 ///
@@ -256,7 +271,12 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
 
     let body =
         fun (model': Model) ->
-            let browser = browserState model'
+        // Nothing to draw without the state that says which folder this is showing. Standing in
+        // for it with an empty one told the user the folder was empty, which is a lie about a
+        // folder nobody had looked in yet.
+        match model'.ProjectBrowser with
+        | None -> div [] []
+        | Some browser ->
             let folder = browser.Folder
             let recents = model'.UserData.RecentProjects |> Option.defaultValue []
             let goTo (path: string) = dispatch <| SetProjectBrowserFolder path

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -179,63 +179,26 @@ let private newProject model dispatch =
 
     
 
-/// The folder the browser is looking at, and the counter that makes it look at the disk again.
-/// Empty when the browser is not open, which the popup never renders in.
+/// The browser's state, or an empty one. The popup only renders while it is Some.
 let private browserState (model: Model) =
-    model.ProjectBrowser |> Option.defaultValue { Folder = ""; Generation = 0 }
+    model.ProjectBrowser
+    |> Option.defaultValue { Folder = ""; Listing = Ok []; Selected = 0 }
 
-type private BrowserListProps = {
-    Folder: string
-    Generation: int
-    Open: string -> unit
-    Navigate: string -> unit
-}
-
-/// The folders inside the one being browsed, each saying what Issie makes of it.
-///
-/// Memoised on the folder and the generation. A popup body runs on every message, so without this
-/// every keystroke in the path field would list whatever prefix had been typed so far; with it,
-/// the disk is read when the folder changes and once a second thereafter. Props holding functions
-/// are exactly what equalsButFunctions is for.
-let private browserList =
-    FunctionComponent.Of(
-        (fun (props: BrowserListProps) ->
-            if not (isDirectory props.Folder) then
-                div [Style [Color "red"; Padding "8px 0"]] [str "That folder does not exist."]
-            else
-                match listFolderForOpening props.Folder with
-                | [] ->
-                    div [Style [Color "grey"; Padding "8px 0"]]
-                        [str "Nothing in this folder. Go up, or type a path above."]
-                | entries ->
-                    Menu.menu [] [
-                        Menu.list []
-                            (entries |> List.map (fun entry ->
-                                let name = baseName entry.Path
-                                let sheets =
-                                    if entry.SheetCount = 1 then "1 sheet" else $"{entry.SheetCount} sheets"
-                                let label, note, act =
-                                    match entry.Kind with
-                                    | IsProject ->
-                                        b [] [str name], span [Style [Color "grey"]] [str sheets], props.Open
-                                    | SheetsButNoMarker ->
-                                        b [] [str name],
-                                        span [Style [Color "darkorange"]] [str $"{sheets}, no project file"],
-                                        props.Open
-                                    // an ordinary folder is not a dead end: it is where the next
-                                    // level of browsing goes
-                                    | NotAProject ->
-                                        span [Style [Color "dimgrey"]] [str name],
-                                        span [Style [Color "grey"]] [str "›"],
-                                        props.Navigate
-                                Menu.Item.li
-                                    [ Menu.Item.IsActive false
-                                      Menu.Item.OnClick (fun _ -> act entry.Path) ]
-                                    [ div [Style [Display DisplayOptions.Flex; JustifyContent "space-between"]]
-                                          [ label; note ] ]))
-                    ]),
-        "ProjectBrowserList",
-        Fable.React.Helpers.equalsButFunctions)
+/// The path as clickable segments, so that going up several levels is one click rather than
+/// several - which is what the Up button alone made it. Explorer's address bar does the same, and
+/// the editable field underneath stays for pasting a path or reaching another drive.
+let private breadcrumbOf (folder: string) (goTo: string -> unit) =
+    // built by walking up from the folder, so each crumb carries the path it stands for rather
+    // than a reassembled one - separators differ between platforms and a rebuilt root is wrong
+    let rec ancestors (path: string) =
+        if isFilesystemRoot path then [path] else ancestors (dirName path) @ [path]
+    Breadcrumb.breadcrumb [Breadcrumb.Size IsSmall] [
+        for path in ancestors folder ->
+            Breadcrumb.item [] [
+                a [ OnClick (fun _ -> goTo path); HTMLAttr.Title path ]
+                  [str (if isFilesystemRoot path then path else baseName path)]
+            ]
+    ]
 
 /// Open the folder the user chose, which may not be a project.
 ///
@@ -243,7 +206,7 @@ let private browserList =
 /// marker has been lost, or a folder that merely contains projects. The last is not a refusal -
 /// it is where browsing continues. Mutually recursive with the browser, since the browser opens
 /// folders and an unopenable folder puts the browser back.
-let rec private openChosenFolder (path: string) model dispatch =
+let rec openChosenFolder (path: string) model dispatch =
     /// Turning the spinner back off: it is put on in the hope of showing during a load, and every
     /// way out of here that does not load something would otherwise leave it spinning over an
     /// unchanged app.
@@ -303,23 +266,80 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
                 // model' rather than the model this popup was opened with: opening reads the
                 // recent list to add to it, and the popup outlives whatever else has happened
                 openChosenFolder path model' dispatch
-            div [] [
-                if not (List.isEmpty recents) then
-                    div [Style [MarginBottom "10px"]] [
-                        b [] [str "Recent"]
+            /// Places on the left, contents on the right - the layout every file dialog has,
+            /// borrowed because it solves a real problem here: ten recents stacked above the
+            /// listing pushed the folder's own contents below the fold.
+            let places =
+                div [Style [Width "180px"; MarginRight "12px"; Flex "0 0 auto"]] [
+                    b [] [str "Recent"]
+                    match recents with
+                    | [] -> div [Style [Color "grey"; FontSize "12px"]] [str "Nothing yet."]
+                    | recents ->
                         Menu.menu [] [
                             Menu.list []
                                 (recents |> List.map (fun path ->
                                     Menu.Item.li
                                         [ Menu.Item.IsActive false
                                           Menu.Item.OnClick (fun _ -> openIt path) ]
-                                        [ div [HTMLAttr.Title path]
-                                              [str (cropToLength Constants.maxDisplayedPathLengthInRecentProjects false path)] ]))
+                                        // both axes hidden: hiding only one makes CSS force the
+                                        // other to auto, which put a scrollbar on every row
+                                        [ div [ HTMLAttr.Title path
+                                                Style [OverflowX OverflowOptions.Hidden
+                                                       OverflowY OverflowOptions.Hidden
+                                                       TextOverflow "ellipsis"
+                                                       WhiteSpace WhiteSpaceOptions.Nowrap] ]
+                                              [str (baseName path)] ]))
                         ]
-                    ]
-                    hr []
+                ]
 
-                b [] [str "Folder"]
+            /// Fixed height and scrolling inside itself, so that the path bar above it stays put
+            /// however many folders there are. The whole dialog used to scroll together, which put
+            /// the path bar out of reach in any large folder.
+            let contents =
+                div [Style [
+                        Flex "1"; MinWidth "0"
+                        Height Constants.projectBrowserListHeight
+                        OverflowY OverflowOptions.Auto
+                        Border "1px solid lightgrey"; BorderRadius "4px" ]] [
+                    match browser.Listing with
+                    | Error message ->
+                        div [Style [Color "red"; Padding "8px"]] [str message]
+                    | Ok [] ->
+                        div [Style [Color "grey"; Padding "8px"]]
+                            [str "Nothing in this folder. Go up, or type a path above."]
+                    | Ok entries ->
+                        Menu.menu [] [
+                            Menu.list []
+                                (entries |> List.mapi (fun i entry ->
+                                    let name = baseName entry.Path
+                                    let sheets =
+                                        if entry.SheetCount = 1 then "1 sheet" else $"{entry.SheetCount} sheets"
+                                    let label, note, act =
+                                        match entry.Kind with
+                                        | IsProject ->
+                                            b [] [str name], span [Style [Color "grey"]] [str sheets], openIt
+                                        | SheetsButNoMarker ->
+                                            b [] [str name],
+                                            span [Style [Color "darkorange"]] [str $"{sheets}, no project file"],
+                                            openIt
+                                        // an ordinary folder is not a dead end: it is where the
+                                        // next level of browsing goes
+                                        | NotAProject ->
+                                            span [Style [Color "dimgrey"]] [str name],
+                                            span [Style [Color "grey"]] [str "›"],
+                                            goTo
+                                    Menu.Item.li
+                                        // the row the keyboard is on, shown the way Bulma shows a
+                                        // selected menu item so it reads as one thing with a click
+                                        [ Menu.Item.IsActive (i = browser.Selected)
+                                          Menu.Item.OnClick (fun _ -> act entry.Path) ]
+                                        [ div [Style [Display DisplayOptions.Flex; JustifyContent "space-between"]]
+                                              [ label; note ] ]))
+                        ]
+                ]
+
+            div [] [
+                breadcrumbOf folder goTo
                 div [Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.Center; MarginBottom "8px"]] [
                     // typed as well as walked to, which is how another drive or a share is reached
                     // without this becoming a file manager
@@ -330,16 +350,10 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
                             Input.OnChange (getTextEventValue >> SetProjectBrowserFolder >> dispatch)
                         ]
                     ]
-                    Button.button [
-                        Button.Size IsSmall
-                        Button.Disabled (isFilesystemRoot folder)
-                        Button.OnClick (fun _ -> goTo (dirName folder))
-                    ] [str "Up"]
                     // No Refresh button: the folder is re-read once a second while this is open,
                     // so a folder made or renamed outside Issie simply appears.
                     Button.button [
                         Button.Size IsSmall
-                        Button.Props [Style [MarginLeft "4px"]]
                         Button.OnClick (fun _ ->
                             askForFolder "Choose a project folder, or a folder of projects" "Use this folder"
                                 (Some folder)
@@ -351,16 +365,44 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
                                 | _ -> openIt chosen))
                     ] [str "Browse..."]
                 ]
-
-                browserList {
-                    Folder = folder
-                    Generation = browser.Generation
-                    Open = openIt
-                    Navigate = goTo
-                }
+                div [Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.FlexStart]] [places; contents]
+                div [Style [Color "grey"; FontSize "12px"; MarginTop "6px"]] [
+                    str "Arrow keys move, Enter opens, Backspace goes up."
+                ]
             ]
 
-    dynamicClosablePopup "Open project" body (fun _ -> div [] []) [Width "640px"] dispatch
+    let foot =
+        fun (_: Model) ->
+            Level.level [Level.Level.Props [Style [Width "100%"]]] [
+                Level.left [] []
+                Level.right [] [
+                    Level.item [] [
+                        Button.button [Button.Color IsLight; Button.OnClick (fun _ -> dispatch ClosePopup)]
+                            [str "Cancel"]
+                    ]
+                ]
+            ]
+
+    dynamicClosablePopup "Open project" body foot [Width "700px"] dispatch
+
+/// Act on the row the project browser's keyboard selection is on: a project opens, an ordinary
+/// folder is entered - the same two things a click on that row does.
+let activateBrowserSelection (model: Model) dispatch =
+    match model.ProjectBrowser with
+    | Some browser ->
+        match browser.Listing with
+        | Ok entries ->
+            match List.tryItem browser.Selected entries with
+            | Some entry ->
+                match entry.Kind with
+                | NotAProject -> dispatch (SetProjectBrowserFolder entry.Path)
+                | _ ->
+                    dispatch ClosePopup
+                    dispatch (Sheet (SheetT.SetSpinner true))
+                    openChosenFolder entry.Path model dispatch
+            | None -> ()
+        | Error _ -> ()
+    | None -> ()
 
 /// open an existing project
 let private openProject model dispatch =

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -179,12 +179,10 @@ let private newProject model dispatch =
 
     
 
-/// The folder the browser is looking at. Kept in the dialog text rather than in a model field of
-/// its own, because ClosePopup already clears that: the browser cannot leave state behind it.
-let private browsingAt (model: Model) = getText model.PopupDialogData
-
-/// Bumped by Refresh, so that the same folder can be read again.
-let private browserGeneration (model: Model) = model.PopupDialogData.Int |> Option.defaultValue 0
+/// The folder the browser is looking at, and the counter that makes it look at the disk again.
+/// Empty when the browser is not open, which the popup never renders in.
+let private browserState (model: Model) =
+    model.ProjectBrowser |> Option.defaultValue { Folder = ""; Generation = 0 }
 
 type private BrowserListProps = {
     Folder: string
@@ -195,9 +193,10 @@ type private BrowserListProps = {
 
 /// The folders inside the one being browsed, each saying what Issie makes of it.
 ///
-/// Memoised on the folder and the refresh generation because reading a directory is a disk access
-/// and a popup body runs on every message: without this, browsing would re-read the filesystem
-/// continuously. Props holding functions are exactly what equalsButFunctions is for.
+/// Memoised on the folder and the generation. A popup body runs on every message, so without this
+/// every keystroke in the path field would list whatever prefix had been typed so far; with it,
+/// the disk is read when the folder changes and once a second thereafter. Props holding functions
+/// are exactly what equalsButFunctions is for.
 let private browserList =
     FunctionComponent.Of(
         (fun (props: BrowserListProps) ->
@@ -290,14 +289,14 @@ let rec private openChosenFolder (path: string) model dispatch =
 /// remains, as Browse, for the places this list will not reach: another drive, a share, anywhere
 /// worth typing rather than walking to.
 and private viewProjectBrowser (startFolder: string) model dispatch =
-    dispatch <| SetPopupDialogText (Some startFolder)
-    dispatch <| SetPopupDialogInt (Some 0)
+    dispatch <| SetProjectBrowserFolder startFolder
 
     let body =
         fun (model': Model) ->
-            let folder = browsingAt model'
+            let browser = browserState model'
+            let folder = browser.Folder
             let recents = model'.UserData.RecentProjects |> Option.defaultValue []
-            let goTo (path: string) = dispatch <| SetPopupDialogText (Some path)
+            let goTo (path: string) = dispatch <| SetProjectBrowserFolder path
             let openIt (path: string) =
                 dispatch ClosePopup
                 dispatch (Sheet (SheetT.SetSpinner true))
@@ -328,7 +327,7 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
                         Input.text [
                             Input.Value folder
                             Input.Props [SpellCheck false; Style [FontFamily "monospace"]]
-                            Input.OnChange (getTextEventValue >> Some >> SetPopupDialogText >> dispatch)
+                            Input.OnChange (getTextEventValue >> SetProjectBrowserFolder >> dispatch)
                         ]
                     ]
                     Button.button [
@@ -336,14 +335,8 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
                         Button.Disabled (isFilesystemRoot folder)
                         Button.OnClick (fun _ -> goTo (dirName folder))
                     ] [str "Up"]
-                    Button.button [
-                        Button.Size IsSmall
-                        Button.Props [Style [MarginLeft "4px"]]
-                        // re-read the same folder: the generation is what the memoised list
-                        // notices, since the path it is keyed on has not changed
-                        Button.OnClick (fun _ ->
-                            dispatch <| SetPopupDialogInt (Some (browserGeneration model' + 1)))
-                    ] [str "Refresh"]
+                    // No Refresh button: the folder is re-read once a second while this is open,
+                    // so a folder made or renamed outside Issie simply appears.
                     Button.button [
                         Button.Size IsSmall
                         Button.Props [Style [MarginLeft "4px"]]
@@ -361,7 +354,7 @@ and private viewProjectBrowser (startFolder: string) model dispatch =
 
                 browserList {
                     Folder = folder
-                    Generation = browserGeneration model'
+                    Generation = browser.Generation
                     Open = openIt
                     Navigate = goTo
                 }

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -179,57 +179,103 @@ let private newProject model dispatch =
 
     
 
-/// open an existing project
+/// Open the folder the user chose, which may not be a project.
 ///
-/// The dialog asks for a folder, so a folder is what has to be checked: it may hold no sheets at
-/// all, and it may hold sheets without the marker that says it is a project. Neither is a reason
-/// to say nothing, which is what a filtered file dialog did by simply refusing to offer it.
+/// A folder picker draws every folder alike, so what comes back has to be judged rather than
+/// assumed: it may be a project, a project whose marker has been lost, the folder the user's
+/// projects live IN, or nothing to do with Issie. Only the last is a dead end, and even that is
+/// said out loud. Recursive because choosing from the projects found inside a folder arrives back
+/// here, and one of those may itself be missing its marker.
+let rec private openChosenFolder (path: string) model dispatch =
+    /// Turning the spinner back off: it is put on in the hope of showing during a load, and every
+    /// way out of here that does not load something would otherwise leave it spinning over an
+    /// unchanged app.
+    let giveUp () = dispatch (Sheet (SheetT.SetSpinner false))
+    match inspectProjectDirectory path with
+    | IsProject -> openProjectFromPath path model dispatch
+
+    | SheetsButNoMarker ->
+        // Loadable, and worth loading: the sheets are the project. The marker is what says so to
+        // everything that has only the folder to go on, so offer to put it back rather than either
+        // refusing the folder or writing to it uninvited.
+        giveUp ()
+        choicePopup
+            "Add the missing project file?"
+            (div [] [
+                str $"'{baseName path}' holds Issie sheets but no .dprj project file, which is \
+                      what marks a folder as an Issie project."
+                br []; br []
+                str $"Issie can open it either way. Adding {baseName path}.dprj lets it be \
+                      recognised as a project in future." ])
+            "Add it and open"
+            "Open without it"
+            (fun addMarker _ ->
+                dispatch ClosePopup
+                if addMarker then
+                    writeFile (projectMarkerPath path) ""
+                    |> Notifications.displayAlertOnError dispatch
+                openProjectFromPath path model dispatch)
+            dispatch
+
+    | NotAProject ->
+        giveUp ()
+        match projectsWithin path with
+        | [] ->
+            closablePopup
+                "Not an Issie project"
+                (div [] [
+                    str $"'{path}' is not an Issie project, and holds none."
+                    br []; br []
+                    str "An Issie project is a folder of .dgm sheet files, marked by a .dprj file \
+                         of the same name as the folder. Choose such a folder, or the folder your \
+                         projects are kept in." ])
+                (div [] [])
+                []
+                dispatch
+        | found ->
+            // The folder the projects live in, which is at least as likely a thing to browse to as
+            // a project itself - and which the picker gives no way to tell apart from one. Offering
+            // what is inside turns the near miss into the thing that was wanted.
+            closablePopup
+                "Projects in this folder"
+                (div [] [
+                    str $"'{path}' is not itself an Issie project, but it contains these. \
+                          Choose one to open it."
+                    br []; br []
+                    Menu.menu [] [
+                        Menu.list []
+                            (found |> List.map (fun (projectPath, kind) ->
+                                Menu.Item.li
+                                    [ Menu.Item.IsActive false
+                                      Menu.Item.OnClick (fun _ ->
+                                        dispatch ClosePopup
+                                        dispatch (Sheet (SheetT.SetSpinner true))
+                                        openChosenFolder projectPath model dispatch) ]
+                                    [ div [] [
+                                        str (baseName projectPath)
+                                        match kind with
+                                        | SheetsButNoMarker ->
+                                            span [Style [Color "grey"; MarginLeft "8px"]]
+                                                 [str "(sheets, but no project file)"]
+                                        | _ -> null ] ]))
+                    ] ])
+                (div [] [])
+                []
+                dispatch
+
+/// open an existing project
 let private openProject model dispatch =
     //trying to force the spinner to load earlier
     //doesn't really work right now
     warnAppWidth dispatch (fun _ ->
     dispatch (Sheet (SheetT.SetSpinner true))
-    /// Every way out of here that does not open a project has to put the spinner back: it is
-    /// turned on above in the hope of showing during the load, and a load that never starts would
-    /// otherwise leave it spinning over an unchanged app.
-    let giveUp () = dispatch (Sheet (SheetT.SetSpinner false))
     let dirName =
         match Option.map readFilesFromDirectory model.UserData.LastUsedDirectory with
         | Some [] | None -> None
         | _ -> model.UserData.LastUsedDirectory
     match askForExistingProjectPath dirName with
-    | None -> giveUp () // User gave no path.
-    | Some path ->
-        match inspectProjectDirectory path with
-        | IsProject -> openProjectFromPath path model dispatch
-        | NotAProject ->
-            giveUp ()
-            displayFileErrorNotification
-                $"'{path}' holds no Issie sheets, so there is no project here to open. \
-                  An Issie project is a folder of .dgm sheet files."
-                dispatch
-        | SheetsButNoMarker ->
-            // Loadable, and worth loading: the sheets are the project. The marker is what says so
-            // to everything that has only the folder to go on, so offer to put it back rather
-            // than either refusing the folder or writing to it uninvited.
-            giveUp ()
-            choicePopup
-                "Add the missing project file?"
-                (div [] [
-                    str $"'{path}' holds Issie sheets but no .dprj project file, which is what \
-                          marks a folder as an Issie project."
-                    br []; br []
-                    str $"Issie can open it either way. Adding {baseName path}.dprj lets it be \
-                          recognised as a project in future." ])
-                "Add it and open"
-                "Open without it"
-                (fun addMarker _ ->
-                    dispatch ClosePopup
-                    if addMarker then
-                        writeFile (projectMarkerPath path) ""
-                        |> Notifications.displayAlertOnError dispatch
-                    openProjectFromPath path model dispatch)
-                dispatch)
+    | None -> dispatch (Sheet (SheetT.SetSpinner false)) // User gave no path.
+    | Some path -> openChosenFolder path model dispatch)
 
 /// Close current project, if any.
 let forceCloseProject (model:Model) dispatch =

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -1,7 +1,9 @@
 ﻿module FileUpdate
 open Elmish
+open Fulma
 open Fable.React
 open Fable.React.Props
+open Helpers
 open ModelType
 open ElectronAPI
 open FilesIO
@@ -58,46 +60,176 @@ let doActionWithSaveFileDialog (name: string) (nextAction: Msg)  model dispatch 
     else
         dispatch nextAction
 
-/// Create a new project.
-let rec private newProject model dispatch  =
+/// Create the project directory, its marker and its first sheet, and open it.
+let private createProjectAt (path: string) model dispatch =
+    match tryCreateFolder path with
+    | Error err ->
+        JSHelpers.log err
+        displayFileErrorNotification err dispatch
+    | Ok _ ->
+        dispatch EndSimulation // End any running simulation.
+        dispatch <| TruthTableMsg CloseTruthTable // Close any open Truth Table.
+        dispatch EndWaveSim
+        // Create empty placeholder projectFile.
+        writeFile (projectMarkerPath path) ""
+        |> Notifications.displayAlertOnError dispatch
+        // Create empty initial diagram file.
+        let initialComponent = createEmptyComponentAndFile path "main"
+        dispatch <| SetUserData {model.UserData with LastUsedDirectory = Some path}
+        setupProjectFromComponents false "main" [initialComponent] model dispatch
+
+/// Where a new project of this name, in this folder, would go - or why it would not go anywhere.
+///
+/// Every objection the creation used to raise after the event is asked here instead, of what the
+/// user has typed so far, so that the Create button can say whether it would work rather than the
+/// user finding out by pressing it.
+let private newProjectPath (parent: string) (name: string) : Result<string, string> =
+    match projectNameError name with
+    | Some err -> Error err
+    | None when parent = "" -> Error "Choose the folder to create the project in."
+    | None when not (isDirectory parent) -> Error $"'{parent}' is not a folder."
+    | None when inspectProjectDirectory parent = IsProject ->
+        Error $"'{baseName parent}' is itself an Issie project, and a project cannot contain another."
+    | None ->
+        let path = pathJoin [| parent; name |]
+        if exists path then Error $"'{name}' already exists in that folder." else Ok path
+
+/// Create a new project, asking for its name and where to put it.
+///
+/// This was a native SAVE dialog: it asked the user to save a file that was really a directory,
+/// offered to overwrite a folder it would not overwrite, and kept the naming rules to itself until
+/// one was broken - at which point a native error box appeared and the dialog reopened empty. The
+/// form asks the two things that are actually needed, judges them as they are typed, and says what
+/// it is about to create before creating it.
+let private newProject model dispatch =
     warnAppWidth dispatch (fun _ ->
-    match askForNewProjectPath model.UserData.LastUsedDirectory with
-    | None -> () // User gave no path.
-    | Some path ->
-        match tryCreateFolder path with
-        | Error err ->
-            JSHelpers.log err
-            // Show error in a dialog box and then re-open the project creation dialog
-            electronRemote.dialog.showErrorBox("Invalid Project Name", err)
-            newProject model dispatch
-        | Ok _ ->
-            dispatch EndSimulation // End any running simulation.
-            dispatch <| TruthTableMsg CloseTruthTable // Close any open Truth Table.
-            dispatch EndWaveSim
-            // Create empty placeholder projectFile.
-            let projectFile = baseName path + ".dprj"
-            writeFile (pathJoin [| path; projectFile |]) ""
-            |> Notifications.displayAlertOnError dispatch
-            // Create empty initial diagram file.
-            let initialComponent = createEmptyComponentAndFile path "main"
-            dispatch <| SetUserData {model.UserData with LastUsedDirectory = Some path}
-            setupProjectFromComponents false "main" [initialComponent] model dispatch)
+    // The last used directory is the last project opened or created, so the folder holding it is
+    // where this user keeps their projects - a better guess than the directory itself, which would
+    // propose a project inside the last one.
+    let defaultParent =
+        model.UserData.LastUsedDirectory
+        |> Option.map dirName
+        |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
+    dispatch <| SetPopupDialogText (Some "")
+    dispatch <| SetPopupDialogText2 (Some defaultParent)
+
+    let body =
+        fun (model': Model) ->
+            let name = getText model'.PopupDialogData
+            let parent = getText2 model'.PopupDialogData
+            let outcome = newProjectPath parent name
+            div [] [
+                str "What should the project be called?"
+                Input.text [
+                    Input.Props [AutoFocus true; SpellCheck false]
+                    Input.Placeholder "Project name"
+                    Input.OnChange (getTextEventValue >> Some >> SetPopupDialogText >> dispatch)
+                ]
+                br []
+                str "Where should it go?"
+                div [Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.Center]] [
+                    // Typed as well as browsed: a path can be pasted, which the dialog alone never
+                    // allowed. Controlled by the dialog text so that Browse writes into it.
+                    div [Style [Flex "1"; MarginRight "8px"]] [
+                        Input.text [
+                            Input.Value parent
+                            Input.Props [SpellCheck false; Style [FontFamily "monospace"]]
+                            Input.Placeholder "Folder to create the project in"
+                            Input.OnChange (getTextEventValue >> Some >> SetPopupDialogText2 >> dispatch)
+                        ]
+                    ]
+                    Button.button [
+                        Button.Size IsSmall
+                        Button.OnClick (fun _ ->
+                            askForFolder "Where should the project folder go?" "Use this folder"
+                                (Some parent)
+                            |> Option.iter (Some >> SetPopupDialogText2 >> dispatch))
+                    ] [str "Browse..."]
+                ]
+                br []
+                // Said before it happens, because a project is a directory of files rather than
+                // the one file the old save dialog implied, and nothing else tells the user that.
+                match outcome with
+                | Ok path ->
+                    div [Style [Color "green"]] [
+                        str $"Will create the folder {path}, holding {name}.dprj and the first \
+                              sheet, main.dgm."
+                    ]
+                | Error err ->
+                    // "enter a name" is what an untouched form always says: it is a prompt rather
+                    // than a complaint, so it is not dressed as one.
+                    let untouched = name = "" && parent <> ""
+                    div [Style [Color (if untouched then "grey" else "red")]] [str err]
+            ]
+
+    let buttonAction =
+        fun (model': Model) ->
+            match newProjectPath (getText2 model'.PopupDialogData) (getText model'.PopupDialogData) with
+            | Ok path ->
+                dispatch ClosePopup
+                createProjectAt path model dispatch
+            | Error _ -> () // unreachable: the button is disabled until this is Ok
+
+    let isDisabled =
+        fun (model': Model) ->
+            newProjectPath (getText2 model'.PopupDialogData) (getText model'.PopupDialogData)
+            |> Result.isError
+
+    dialogPopup "New project" body "Create" buttonAction isDisabled [] dispatch)
 
     
 
 /// open an existing project
+///
+/// The dialog asks for a folder, so a folder is what has to be checked: it may hold no sheets at
+/// all, and it may hold sheets without the marker that says it is a project. Neither is a reason
+/// to say nothing, which is what a filtered file dialog did by simply refusing to offer it.
 let private openProject model dispatch =
     //trying to force the spinner to load earlier
     //doesn't really work right now
-    warnAppWidth dispatch (fun _ -> 
+    warnAppWidth dispatch (fun _ ->
     dispatch (Sheet (SheetT.SetSpinner true))
+    /// Every way out of here that does not open a project has to put the spinner back: it is
+    /// turned on above in the hope of showing during the load, and a load that never starts would
+    /// otherwise leave it spinning over an unchanged app.
+    let giveUp () = dispatch (Sheet (SheetT.SetSpinner false))
     let dirName =
         match Option.map readFilesFromDirectory model.UserData.LastUsedDirectory with
         | Some [] | None -> None
         | _ -> model.UserData.LastUsedDirectory
     match askForExistingProjectPath dirName with
-    | None -> () // User gave no path.
-    | Some path -> openProjectFromPath path model dispatch)
+    | None -> giveUp () // User gave no path.
+    | Some path ->
+        match inspectProjectDirectory path with
+        | IsProject -> openProjectFromPath path model dispatch
+        | NotAProject ->
+            giveUp ()
+            displayFileErrorNotification
+                $"'{path}' holds no Issie sheets, so there is no project here to open. \
+                  An Issie project is a folder of .dgm sheet files."
+                dispatch
+        | SheetsButNoMarker ->
+            // Loadable, and worth loading: the sheets are the project. The marker is what says so
+            // to everything that has only the folder to go on, so offer to put it back rather
+            // than either refusing the folder or writing to it uninvited.
+            giveUp ()
+            choicePopup
+                "Add the missing project file?"
+                (div [] [
+                    str $"'{path}' holds Issie sheets but no .dprj project file, which is what \
+                          marks a folder as an Issie project."
+                    br []; br []
+                    str $"Issie can open it either way. Adding {baseName path}.dprj lets it be \
+                          recognised as a project in future." ])
+                "Add it and open"
+                "Open without it"
+                (fun addMarker _ ->
+                    dispatch ClosePopup
+                    if addMarker then
+                        writeFile (projectMarkerPath path) ""
+                        |> Notifications.displayAlertOnError dispatch
+                    openProjectFromPath path model dispatch)
+                dispatch)
 
 /// Close current project, if any.
 let forceCloseProject (model:Model) dispatch =

--- a/src/Renderer/UI/FileUpdate.fs
+++ b/src/Renderer/UI/FileUpdate.fs
@@ -179,13 +179,71 @@ let private newProject model dispatch =
 
     
 
+/// The folder the browser is looking at. Kept in the dialog text rather than in a model field of
+/// its own, because ClosePopup already clears that: the browser cannot leave state behind it.
+let private browsingAt (model: Model) = getText model.PopupDialogData
+
+/// Bumped by Refresh, so that the same folder can be read again.
+let private browserGeneration (model: Model) = model.PopupDialogData.Int |> Option.defaultValue 0
+
+type private BrowserListProps = {
+    Folder: string
+    Generation: int
+    Open: string -> unit
+    Navigate: string -> unit
+}
+
+/// The folders inside the one being browsed, each saying what Issie makes of it.
+///
+/// Memoised on the folder and the refresh generation because reading a directory is a disk access
+/// and a popup body runs on every message: without this, browsing would re-read the filesystem
+/// continuously. Props holding functions are exactly what equalsButFunctions is for.
+let private browserList =
+    FunctionComponent.Of(
+        (fun (props: BrowserListProps) ->
+            if not (isDirectory props.Folder) then
+                div [Style [Color "red"; Padding "8px 0"]] [str "That folder does not exist."]
+            else
+                match listFolderForOpening props.Folder with
+                | [] ->
+                    div [Style [Color "grey"; Padding "8px 0"]]
+                        [str "Nothing in this folder. Go up, or type a path above."]
+                | entries ->
+                    Menu.menu [] [
+                        Menu.list []
+                            (entries |> List.map (fun entry ->
+                                let name = baseName entry.Path
+                                let sheets =
+                                    if entry.SheetCount = 1 then "1 sheet" else $"{entry.SheetCount} sheets"
+                                let label, note, act =
+                                    match entry.Kind with
+                                    | IsProject ->
+                                        b [] [str name], span [Style [Color "grey"]] [str sheets], props.Open
+                                    | SheetsButNoMarker ->
+                                        b [] [str name],
+                                        span [Style [Color "darkorange"]] [str $"{sheets}, no project file"],
+                                        props.Open
+                                    // an ordinary folder is not a dead end: it is where the next
+                                    // level of browsing goes
+                                    | NotAProject ->
+                                        span [Style [Color "dimgrey"]] [str name],
+                                        span [Style [Color "grey"]] [str "›"],
+                                        props.Navigate
+                                Menu.Item.li
+                                    [ Menu.Item.IsActive false
+                                      Menu.Item.OnClick (fun _ -> act entry.Path) ]
+                                    [ div [Style [Display DisplayOptions.Flex; JustifyContent "space-between"]]
+                                          [ label; note ] ]))
+                    ]),
+        "ProjectBrowserList",
+        Fable.React.Helpers.equalsButFunctions)
+
 /// Open the folder the user chose, which may not be a project.
 ///
-/// A folder picker draws every folder alike, so what comes back has to be judged rather than
-/// assumed: it may be a project, a project whose marker has been lost, the folder the user's
-/// projects live IN, or nothing to do with Issie. Only the last is a dead end, and even that is
-/// said out loud. Recursive because choosing from the projects found inside a folder arrives back
-/// here, and one of those may itself be missing its marker.
+/// What is chosen has to be judged rather than assumed: it may be a project, a project whose
+/// marker has been lost, or a folder that merely contains projects. The last is not a refusal -
+/// it is where browsing continues. Mutually recursive with the browser, since the browser opens
+/// folders and an unopenable folder puts the browser back.
 let rec private openChosenFolder (path: string) model dispatch =
     /// Turning the spinner back off: it is put on in the hope of showing during a load, and every
     /// way out of here that does not load something would otherwise leave it spinning over an
@@ -217,65 +275,111 @@ let rec private openChosenFolder (path: string) model dispatch =
                 openProjectFromPath path model dispatch)
             dispatch
 
+    // Not something to open, so it is something to look inside: browsing continues there. This is
+    // the case a native folder picker cannot help with, since it draws the folder holding your
+    // projects exactly like the projects themselves.
     | NotAProject ->
         giveUp ()
-        match projectsWithin path with
-        | [] ->
-            closablePopup
-                "Not an Issie project"
-                (div [] [
-                    str $"'{path}' is not an Issie project, and holds none."
-                    br []; br []
-                    str "An Issie project is a folder of .dgm sheet files, marked by a .dprj file \
-                         of the same name as the folder. Choose such a folder, or the folder your \
-                         projects are kept in." ])
-                (div [] [])
-                []
-                dispatch
-        | found ->
-            // The folder the projects live in, which is at least as likely a thing to browse to as
-            // a project itself - and which the picker gives no way to tell apart from one. Offering
-            // what is inside turns the near miss into the thing that was wanted.
-            closablePopup
-                "Projects in this folder"
-                (div [] [
-                    str $"'{path}' is not itself an Issie project, but it contains these. \
-                          Choose one to open it."
-                    br []; br []
-                    Menu.menu [] [
-                        Menu.list []
-                            (found |> List.map (fun (projectPath, kind) ->
-                                Menu.Item.li
-                                    [ Menu.Item.IsActive false
-                                      Menu.Item.OnClick (fun _ ->
-                                        dispatch ClosePopup
-                                        dispatch (Sheet (SheetT.SetSpinner true))
-                                        openChosenFolder projectPath model dispatch) ]
-                                    [ div [] [
-                                        str (baseName projectPath)
-                                        match kind with
-                                        | SheetsButNoMarker ->
-                                            span [Style [Color "grey"; MarginLeft "8px"]]
-                                                 [str "(sheets, but no project file)"]
-                                        | _ -> null ] ]))
-                    ] ])
-                (div [] [])
-                []
-                dispatch
+        viewProjectBrowser path model dispatch
+
+/// Choose a project to open, from a list Issie draws itself.
+///
+/// A native folder picker cannot show which folders are projects - it has no idea - so browsing in
+/// one is guesswork until something is chosen. Here every folder says what it is before it is
+/// picked, and an ordinary folder is a way further in rather than a mistake. The system dialog
+/// remains, as Browse, for the places this list will not reach: another drive, a share, anywhere
+/// worth typing rather than walking to.
+and private viewProjectBrowser (startFolder: string) model dispatch =
+    dispatch <| SetPopupDialogText (Some startFolder)
+    dispatch <| SetPopupDialogInt (Some 0)
+
+    let body =
+        fun (model': Model) ->
+            let folder = browsingAt model'
+            let recents = model'.UserData.RecentProjects |> Option.defaultValue []
+            let goTo (path: string) = dispatch <| SetPopupDialogText (Some path)
+            let openIt (path: string) =
+                dispatch ClosePopup
+                dispatch (Sheet (SheetT.SetSpinner true))
+                // model' rather than the model this popup was opened with: opening reads the
+                // recent list to add to it, and the popup outlives whatever else has happened
+                openChosenFolder path model' dispatch
+            div [] [
+                if not (List.isEmpty recents) then
+                    div [Style [MarginBottom "10px"]] [
+                        b [] [str "Recent"]
+                        Menu.menu [] [
+                            Menu.list []
+                                (recents |> List.map (fun path ->
+                                    Menu.Item.li
+                                        [ Menu.Item.IsActive false
+                                          Menu.Item.OnClick (fun _ -> openIt path) ]
+                                        [ div [HTMLAttr.Title path]
+                                              [str (cropToLength Constants.maxDisplayedPathLengthInRecentProjects false path)] ]))
+                        ]
+                    ]
+                    hr []
+
+                b [] [str "Folder"]
+                div [Style [Display DisplayOptions.Flex; AlignItems AlignItemsOptions.Center; MarginBottom "8px"]] [
+                    // typed as well as walked to, which is how another drive or a share is reached
+                    // without this becoming a file manager
+                    div [Style [Flex "1"; MarginRight "8px"]] [
+                        Input.text [
+                            Input.Value folder
+                            Input.Props [SpellCheck false; Style [FontFamily "monospace"]]
+                            Input.OnChange (getTextEventValue >> Some >> SetPopupDialogText >> dispatch)
+                        ]
+                    ]
+                    Button.button [
+                        Button.Size IsSmall
+                        Button.Disabled (isFilesystemRoot folder)
+                        Button.OnClick (fun _ -> goTo (dirName folder))
+                    ] [str "Up"]
+                    Button.button [
+                        Button.Size IsSmall
+                        Button.Props [Style [MarginLeft "4px"]]
+                        // re-read the same folder: the generation is what the memoised list
+                        // notices, since the path it is keyed on has not changed
+                        Button.OnClick (fun _ ->
+                            dispatch <| SetPopupDialogInt (Some (browserGeneration model' + 1)))
+                    ] [str "Refresh"]
+                    Button.button [
+                        Button.Size IsSmall
+                        Button.Props [Style [MarginLeft "4px"]]
+                        Button.OnClick (fun _ ->
+                            askForFolder "Choose a project folder, or a folder of projects" "Use this folder"
+                                (Some folder)
+                            |> Option.iter (fun chosen ->
+                                // whatever was chosen, honour the intent: open it if it can be
+                                // opened, otherwise carry on browsing from there
+                                match inspectProjectDirectory chosen with
+                                | NotAProject -> goTo chosen
+                                | _ -> openIt chosen))
+                    ] [str "Browse..."]
+                ]
+
+                browserList {
+                    Folder = folder
+                    Generation = browserGeneration model'
+                    Open = openIt
+                    Navigate = goTo
+                }
+            ]
+
+    dynamicClosablePopup "Open project" body (fun _ -> div [] []) [Width "640px"] dispatch
 
 /// open an existing project
 let private openProject model dispatch =
-    //trying to force the spinner to load earlier
-    //doesn't really work right now
     warnAppWidth dispatch (fun _ ->
-    dispatch (Sheet (SheetT.SetSpinner true))
-    let dirName =
-        match Option.map readFilesFromDirectory model.UserData.LastUsedDirectory with
-        | Some [] | None -> None
-        | _ -> model.UserData.LastUsedDirectory
-    match askForExistingProjectPath dirName with
-    | None -> dispatch (Sheet (SheetT.SetSpinner false)) // User gave no path.
-    | Some path -> openChosenFolder path model dispatch)
+    // Where this user keeps their projects: the folder holding the last one they had open, which
+    // is where the next one almost always is. The project itself would show only its sheets.
+    let start =
+        model.UserData.LastUsedDirectory
+        |> Option.filter isDirectory
+        |> Option.map dirName
+        |> Option.defaultValue (electronRemote.app.getPath ElectronAPI.Electron.AppGetPath.Documents)
+    viewProjectBrowser start model dispatch)
 
 /// Close current project, if any.
 let forceCloseProject (model:Model) dispatch =

--- a/src/Renderer/UI/KeyBindings.fs
+++ b/src/Renderer/UI/KeyBindings.fs
@@ -37,6 +37,9 @@ let contextOfModel (m: Model) : KeyContext =
     // requiring both is the accurate test rather than a defence against one of them latching.
     if m.CodeEditorState.IsSome && m.PopupViewFunc.IsSome then
         CodeEditor
+    // before Popup, since the browser IS a popup and wants arrows and Enter that no other one does
+    elif m.ProjectBrowser.IsSome && m.PopupViewFunc.IsSome then
+        ProjectBrowser
     elif m.PopupViewFunc.IsSome || m.SpinnerPayload.IsSome || m.PopupDialogData.Progress.IsSome then
         Popup
     elif
@@ -200,6 +203,11 @@ let actionOf (id: ShortcutId) (dispatch: Msg -> unit) : unit =
     // ---- escape, one action per context ----
     | ScCancelGesture -> keyDispatch SheetT.KeyboardMsg.ESC
     | ScClosePopup -> dispatch ClosePopup
+    // ---- project browser ----
+    | ScBrowserPrev -> dispatch (MoveProjectBrowserSelection -1)
+    | ScBrowserNext -> dispatch (MoveProjectBrowserSelection 1)
+    | ScBrowserOpen -> dispatch (OpenProjectBrowserSelection dispatch)
+    | ScBrowserParent -> dispatch GoToProjectBrowserParent
     | ScDeselect -> sheetDispatch SheetT.ResetSelection
     | ScLeaveTextBox ->
         // hand the keyboard back to the schematic without reaching for the mouse

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -441,7 +441,11 @@ let displayView model dispatch =
     if model.CurrentProj = None  (* (((purgeTime - lastPurgeTime) > 10000.) && (JSHelpers.Memory.getProcessMemory() > 500))*) then
         div [HTMLAttr.Id "OpenProject"] [
                 TopMenuView.viewNoProjectMenu model dispatch
-                UIPopups.viewPopup model dispatch ]
+                UIPopups.viewPopup model dispatch
+                // Notifications were drawn only once a project was open, so anything that went
+                // wrong on the way to opening one - the screen where opening is all there is to
+                // do - set a notification that nothing rendered, and looked like silence.
+                Notifications.viewNotifications model dispatch ]
     elif model.TopMenuOpenState = TransientClosed then
         JSHelpers.delayedDispatch dispatch 1000 (SetTopMenu Closed) |> ignore
         div [] []

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -91,6 +91,7 @@ let init() = {
     SavedSheetIsOutOfDate = false
     PendingDragAddition = None
     DragPlacement = None
+    ProjectBrowser = None
     TopSheetChoiceDeclined = Set.empty
     ComponentLibraries = ComponentLibraries.findLibraries ()
     OpenLibrary = None

--- a/src/Renderer/UI/MenuHelpers.fs
+++ b/src/Renderer/UI/MenuHelpers.fs
@@ -27,7 +27,9 @@ module Constants =
     let minAppWidth = 1060.
     let typicalAppWidth = 1600.
 
-    let numberOfRecentProjects: int  = 5
+    /// Recent projects are now a panel in the project browser rather than a few lines on the
+    /// startup screen, and a term's work is more than five projects.
+    let numberOfRecentProjects: int  = 10
     let maxDisplayedPathLengthInRecentProjects: int  = 60
     /// canvas width < this => use fewer chars in path
     let largeScreenCanvasWidth = 1000

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -18,6 +18,9 @@ module Constants =
     /// read plus one per subfolder in it - a millisecond or so for an ordinary folder, and 14ms
     /// for the worst one on a typical Windows machine - so this costs nothing worth measuring.
     let projectBrowserRefreshMs = 1000
+    /// How tall the project browser's list of folders is. Fixed, and scrolling inside itself, so
+    /// that a folder of 200 subfolders does not push the path bar off the top of the dialog.
+    let projectBrowserListHeight = "300px"
     /// Needed to prevent possible overrun of simulation arrays
     let multipliers = [1;2;5;10;20;50;100;200;500;1000]
     let maxStepsOverflow = 3
@@ -38,6 +41,24 @@ module Constants =
 
     /// initial number of clock cycles navigated by the scrollbar.
     let scrollbarBkgRepCyclesInit = 100
+
+/// Keep a project browser selection on a row that exists. The folder can grow or shrink under it
+/// between one refresh and the next, and an index past the end would leave Enter doing nothing.
+let clampSelection (index: int) (entries: 'a list) =
+    if List.isEmpty entries then 0 else max 0 (min index (List.length entries - 1))
+
+/// Read a folder for the project browser: what is in it, or why it cannot be shown.
+///
+/// Done here, from the update function, rather than while rendering. A popup body runs on every
+/// message, so a view that read the disk would read it continuously - and the keyboard needs the
+/// number of rows before it can move between them.
+let readProjectBrowserFolder (folder: string) (selected: int) : ProjectBrowserState =
+    let listing =
+        if FilesIO.isDirectory folder then Ok (FilesIO.listFolderForOpening folder)
+        else Error "That folder does not exist."
+    { Folder = folder
+      Listing = listing
+      Selected = listing |> Result.map (clampSelection selected) |> Result.defaultValue 0 }
 
 /// type used for CSS grids in the UI to position an item on a grid
 type CSSGridPos =

--- a/src/Renderer/UI/ModelHelpers.fs
+++ b/src/Renderer/UI/ModelHelpers.fs
@@ -13,6 +13,11 @@ open SimTypes
 
 
 module Constants =
+    /// How often the project browser re-reads the folder it is showing, so that a folder made or
+    /// renamed outside Issie appears without being asked for. Listing a folder is one directory
+    /// read plus one per subfolder in it - a millisecond or so for an ordinary folder, and 14ms
+    /// for the worst one on a typical Windows machine - so this costs nothing worth measuring.
+    let projectBrowserRefreshMs = 1000
     /// Needed to prevent possible overrun of simulation arrays
     let multipliers = [1;2;5;10;20;50;100;200;500;1000]
     let maxStepsOverflow = 3

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -198,6 +198,25 @@ let update (msg : Msg) oldModel =
         |> set dragPlacement_ None
         |> withNoMsg
 
+    | SetProjectBrowserFolder folder ->
+        // One refresh chain at a time. Reopening the browser while the last chain is still in
+        // flight must not start a second one, or the folder would be read twice a second, then
+        // four times, and so on.
+        let chainAlreadyRunning = model.ProjectBrowser.IsSome
+        let model = model |> set projectBrowser_ (Some { Folder = folder; Generation = 0 })
+        if chainAlreadyRunning then
+            model |> withNoMsg
+        else
+            model, Cmd.ofMsg (DispatchDelayed (Constants.projectBrowserRefreshMs, TickProjectBrowser))
+
+    | TickProjectBrowser ->
+        match model.ProjectBrowser with
+        // the browser has closed, so the chain ends here rather than ticking on unseen
+        | None -> model |> withNoMsg
+        | Some browser ->
+            model |> set projectBrowser_ (Some { browser with Generation = browser.Generation + 1 }),
+            Cmd.ofMsg (DispatchDelayed (Constants.projectBrowserRefreshMs, TickProjectBrowser))
+
     | SetViewerWidth w ->
         {model with WaveSimViewerWidth = w}
         |> withNoMsg
@@ -472,6 +491,9 @@ let update (msg : Msg) oldModel =
         // nothing.
         { model with
             DragPlacement = None
+            // closing the project browser is what stops its refresh timer: the next tick finds
+            // this None and does not schedule another
+            ProjectBrowser = None
             PopupViewFunc = None;
             CodeEditorState = None
             PopupDialogData =

--- a/src/Renderer/UI/Update.fs
+++ b/src/Renderer/UI/Update.fs
@@ -203,7 +203,8 @@ let update (msg : Msg) oldModel =
         // flight must not start a second one, or the folder would be read twice a second, then
         // four times, and so on.
         let chainAlreadyRunning = model.ProjectBrowser.IsSome
-        let model = model |> set projectBrowser_ (Some { Folder = folder; Generation = 0 })
+        let model =
+            model |> set projectBrowser_ (Some (ModelHelpers.readProjectBrowserFolder folder 0))
         if chainAlreadyRunning then
             model |> withNoMsg
         else
@@ -214,8 +215,31 @@ let update (msg : Msg) oldModel =
         // the browser has closed, so the chain ends here rather than ticking on unseen
         | None -> model |> withNoMsg
         | Some browser ->
-            model |> set projectBrowser_ (Some { browser with Generation = browser.Generation + 1 }),
+            // the selection is kept where it was, but the folder may have shrunk under it
+            model
+            |> set projectBrowser_
+                (Some (ModelHelpers.readProjectBrowserFolder browser.Folder browser.Selected)),
             Cmd.ofMsg (DispatchDelayed (Constants.projectBrowserRefreshMs, TickProjectBrowser))
+
+    | MoveProjectBrowserSelection delta ->
+        model
+        |> Optic.map projectBrowser_ (Option.map (fun browser ->
+            match browser.Listing with
+            | Error _ -> browser
+            | Ok entries ->
+                { browser with
+                    Selected = ModelHelpers.clampSelection (browser.Selected + delta) entries }))
+        |> withNoMsg
+
+    | GoToProjectBrowserParent ->
+        match model.ProjectBrowser with
+        | Some browser when not (isFilesystemRoot browser.Folder) ->
+            model |> withMsg (SetProjectBrowserFolder (dirName browser.Folder))
+        | _ -> model |> withNoMsg
+
+    | OpenProjectBrowserSelection dispatch ->
+        FileUpdate.activateBrowserSelection model dispatch
+        model |> withNoMsg
 
     | SetViewerWidth w ->
         {model with WaveSimViewerWidth = w}

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -197,6 +197,8 @@ let shortDisplayMsg (msg:Msg) =
     // one per mouse move for as long as a catalogue item is being carried: far too many to trace,
     // and each says only where the cursor now is
     | MoveDragPlacement _
+    // one a second for as long as the project browser is open, saying only "look again"
+    | TickProjectBrowser
     // Set width of right-hand pane when tab is WaveSimulator or TruthTable
     | SetViewerWidth _
     | MenuAction _ 
@@ -207,6 +209,7 @@ let shortDisplayMsg (msg:Msg) =
     | StartDragPlacement _ -> Some "StartDragPlacement"
     | DropDragPlacement pos -> Some $"DropDragPlacement at {pos}"
     | EndDragPlacement -> Some "EndDragPlacement"
+    | SetProjectBrowserFolder folder -> Some $"Browsing {folder}"
     | SetIsLoading _
     | SetRouterInteractive _
     | CloseApp

--- a/src/Renderer/UI/UpdateHelpers.fs
+++ b/src/Renderer/UI/UpdateHelpers.fs
@@ -210,6 +210,9 @@ let shortDisplayMsg (msg:Msg) =
     | DropDragPlacement pos -> Some $"DropDragPlacement at {pos}"
     | EndDragPlacement -> Some "EndDragPlacement"
     | SetProjectBrowserFolder folder -> Some $"Browsing {folder}"
+    | MoveProjectBrowserSelection n -> Some $"Browser selection moves by {n}"
+    | GoToProjectBrowserParent -> Some "Browser up"
+    | OpenProjectBrowserSelection _ -> Some "Browser open selection"
     | SetIsLoading _
     | SetRouterInteractive _
     | CloseApp


### PR DESCRIPTION
Opening and creating a project both went through native Electron dialogs that were the wrong shape for the job. This replaces both, and fixes what using the replacements turned up.

## Opening

The open dialog asked for the `.dprj` **file** inside a project — so you navigated into the project, past its own sheets greyed out by the filter, to pick a file that is empty, says nothing, and is named after the folder you were already standing in. Its directory was then all that was kept. A project whose marker had been lost or renamed could not be opened at all, even though loading never reads it.

Asking the OS for a *folder* instead fixed that but lost something real: **a folder picker draws every folder alike, so while browsing you cannot tell which ones are Issie projects.** Neither native dialog can fix this — the `.dprj` filter only revealed a project once you were already inside one, and one level up every subfolder looked the same there too.

So Issie draws the list itself:

<img width="700" alt="Open project dialog" src="https://github.com/user-attachments/assets/placeholder" />

```
Open project                                          [x]

 C: › Users › admin › Desktop
 [ C:\Users\admin\Desktop                  ]  [Browse...]

 Recent          EEP1copy              18 sheets
  keyProj        issieTest              1 sheet
  EEP1copy       regfile2               1 sheet
  adderProj      testlibs               2 sheets
  orphanProj     Verilogtest            1 sheet
  ...            DecaSlides-win-x64            ›
                 marksheets                    ›
                 testsimplification            ›

 Arrow keys move, Enter opens, Backspace goes up.
                                            [Cancel]
```

Every folder says what it is before you pick it — a project with its sheet count, a project whose marker is missing, or an ordinary folder, which is a way further in rather than a mistake. Recents sit in a places column; the path is clickable breadcrumbs over an editable field for pasting a path or reaching another drive; the system dialog remains behind **Browse** for anywhere else. The list is re-read once a second, so a project created, renamed or emptied outside Issie simply appears — including a marker deleted inside one.

## Creating

A native **save** dialog asked the user to save a file that was really a directory, offered to overwrite a folder it would not overwrite, and kept the naming rules to itself until one was broken — at which point an error box appeared and the dialog reopened with the typing gone.

It is now a form: the name judged on every keystroke against the one rule, the folder typed or browsed, and a line stating exactly what will be created (`<parent>/<name>/` holding `<name>.dprj` and `main.dgm`) before it is. "A project cannot contain another" and "that name is taken" are asked of what has been typed, so Create says whether it would work instead of the user finding out by pressing it.

## Also in here

- **The standard Electron menu bar is gone.** The main process never set a menu, so Electron's own File/Edit/View/Window/Help was up from window creation until the renderer removed it across the `@electron/remote` bridge — late, and conditional on that assignment landing. `app.on_ready` now clears it before the first window exists.
- **`readSubdirectories` was doing two syscalls per entry** to find directories, paid on every file it then discarded. `readdirSync` with `withFileTypes` answers it in the call already being made: `C:\Windows\System32` went from 255 ms to 14 ms, of which classifying all 198 subfolders is 11 ms.
- A folder full of projects could read "Nothing in this folder", because the popup stood in an empty state whose listing was `Ok []`.

## Tests

246 passing, up from 238. New: the project-name rule including the two characters its message names; the three things a directory can be; what a folder lists — kinds, sheet counts, projects sorted first, hidden folders and loose files left out; and that a file or a missing path lists nothing rather than failing.

## Verified in the running app

Driven over the DevTools protocol. The browser is in-app, so unlike the native dialogs it can be driven end to end:

- 197 rows scroll inside 298 px while the card stays 600 and the breadcrumbs stay put
- a crumb click goes `C:\Windows` → `C:\` in one; ArrowDown moves the selection; Backspace goes up; Enter opens the selected project
- creating a project folder from outside made the row appear within the second; deleting a sheet changed its count; deleting a marker turned "2 sheets" into "1 sheet, no project file"
- the New Project form defaults its folder to where the last project was kept, refuses `my adder` in red with Create disabled, turns green naming what it will create, and creates exactly that
- a marker-less project raises the offer, and accepting it writes the marker and opens the project

## Two things I want to flag

- **"Nothing in this folder" I could not reproduce.** Typing the path, clicking in from the parent and Backspacing up all listed the folder correctly. The fix addresses a way the code can produce that message wrongly, not one I watched happen. If it recurs, the path in the field at the time will say whether it is the wrong folder or the wrong answer.
- **Closing and reopening the browser within one second** leaves the old refresh timer running beside the new one, since the guard against duplicate chains can only see state that closing has already cleared. Cost is one extra millisecond-scale read per second, and chains die once the browser has been shut for a full second. Fixable with a chain id if you want it exact.
