### PR TITLE
Component polish: catalogue placement, net labels, and three symbols drawn as bodies

### DIFF
--- a/Tests/Issie.Tests/DrawBlockTests.fs
+++ b/Tests/Issie.Tests/DrawBlockTests.fs
@@ -221,6 +221,39 @@ let tests =
             Expect.equal committed.SelectedComponents [ sym.Id ] "and is left selected"
         }
 
+        // A bus select is drawn small - half a grid square high - because it sits in the middle of
+        // wiring laid out around it. Nothing is written inside a body that thin, and rotated it is
+        // thinner still: the bit range goes beside it. Were the range ever moved inside, a rotated
+        // bus select would be 15 pixels wide holding 45 pixels of text.
+        test "a bus select stays small and holds no text, whatever range it selects" {
+            [ 1, 0; 4, 0; 8, 0; 1, 31; 16, 16; 32, 0; 8, 1024 ]
+            |> List.iter (fun (nBits, lsb) ->
+                let ct = BusSelection (nBits, lsb)
+                let comp = Symbol.makeComponent { X = 0.; Y = 0. } ct $"id{nBits}_{lsb}" "SEL"
+                Expect.equal (Symbol.getComponentLegend ct Degree0) ""
+                    "nothing is drawn inside the body, so no rotation of it can clip anything"
+                Expect.equal comp.H (float Symbol.Constants.gridSize / 2.)
+                    "it stays as thin as the line it replaced, so no sheet holding one reflows"
+                Expect.equal comp.W (float Symbol.Constants.gridSize * 2.)
+                    "and as wide, for the same reason"
+                Expect.stringContains (Symbol.busSelectTitle nBits lsb) (string lsb)
+                    "the range drawn beside it names the lsb")
+        }
+
+        // The spreader is the other way about: rare enough to be spelled out, so it is a body of
+        // the usual size with a name on each port, and the wire shape it used to be drawn as is
+        // gone. What matters is that the ports still exist and still say which is which.
+        test "the bus spreader is a body with a named port on each side" {
+            let comp = Symbol.makeComponent { X = 0.; Y = 0. } (NbitSpreader 8) "id" "S1"
+            let inNames, outNames = CanvasStateAnalyser.portNames (NbitSpreader 8)
+            Expect.equal inNames [ "IN" ] "the input is named"
+            Expect.equal outNames [ "OUT" ] "and so is the output"
+            Expect.hasLength comp.InputPorts 1 "one input port"
+            Expect.hasLength comp.OutputPorts 1 "one output port"
+            Expect.stringContains (Symbol.getComponentLegend (NbitSpreader 8) Degree0) "8"
+                "the legend names the width it spreads to"
+        }
+
         test "the separation pass leaves every wire connected and orthogonal" {
             // separation is the pass that nudges parallel wires apart, and the one most likely
             // to move a segment somewhere it should not go

--- a/src/Renderer/Common/WidthInferer.fs
+++ b/src/Renderer/Common/WidthInferer.fs
@@ -800,7 +800,7 @@ let private mapInputPortIdsToVirtualConnectionIds (conns: Connection list) (comp
             match getBusLabelConns compLst  with
             | [cId] -> List.map (fun comp -> (InputPortId comp.InputPorts[0].Id, cId)) compLst |> Ok
             | h when h.Length <> 1 -> Error {
-                Msg = sprintf "A wire label must have exactly one driving component but the label '%s' has %d" lab h.Length
+                Msg = sprintf "A net label must have exactly one driving component but the label '%s' has %d" lab h.Length
                 ConnectionsAffected = h 
                 }            
             | _ -> Ok []

--- a/src/Renderer/DrawBlock/Symbol.fs
+++ b/src/Renderer/DrawBlock/Symbol.fs
@@ -60,16 +60,6 @@ module Constants =
             FontFamily = "Verdana"; 
             FontWeight="500"}
 
-    /// Most fonts now work perfectly - see playground.fs for some tests - add more as needed.
-    /// Style used by bus select bit legends
-    let busSelectStyle: Text = 
-        {defaultText with 
-            TextAnchor = "start"; 
-            FontSize = "12px"; 
-            FontFamily = "helvetica"; 
-            FontWeight="600"}
-
-
     /// Offset between label position and symbol. This is also used as a margin for the label bounding box.
     let componentLabelOffsetDistance: float =  // offset from symbol outline, otehr parameters scale correctly
         if testShowLabelBoundingBoxes then 0. else 7.
@@ -193,10 +183,15 @@ let getSymbolColour compType clocked (theme:ThemeType) =
             -> "lightblue"  //for clocked components
         |Input _ |Input1 (_,_) |Output _ |Viewer _ |Constant _ |Constant1 _ 
             -> "#E8D0A9"  //dark orange: for IO
-        | SplitWire _ | MergeWires | BusSelection _ | NbitSpreader _ | IOLabel | NotConnected ->
+        | SplitWire _ | MergeWires | NotConnected ->
             "rgb(120,120,120)"
-        | MergeN _| SplitN _ -> 
+        | MergeN _| SplitN _ ->
             "lightgray"
+        // The spreader, the bus select and the net label are drawn as bodies rather than as wire
+        // shapes, and being combinational they are drawn in the combinational colour below - the
+        // dark grey above is a stroke colour, and text on it would be the same grey (outlineColor
+        // leaves it alone) on a nearly black fill. A net label is a body too, if a thin one: a
+        // rectangle it can fill when selected rather than a line to recolour.
         | _ -> "rgba(255,255,217,1)" //lightyellow: for combinational components
 
 
@@ -283,10 +278,9 @@ let nBitsGateTitle (gateType:string) (n:int) : string =
     |_ -> (string n) + "-bit." + gateType+ "-N"
 
 ///Insert titles for bus select
-/// used once 
-let busSelectTitle (wob:int) (lsb:int) : string = 
+let busSelectTitle (wob:int) (lsb:int) : string =
     match wob with
-    | 1 -> $"{lsb}"
+    | 1 -> $"({lsb})"
     | _ when wob > 1 -> $"({wob+lsb-1}:{lsb})"
     | _ -> failwith "non positive bus width in bustitle"
 
@@ -381,6 +375,12 @@ let getComponentLegend (componentType:ComponentType) (rotation:Rotation) =
     | Custom x -> x.Name.ToUpper()
     | MergeN _ -> "Merge"
     | SplitN _ -> "Split"
+    // Says the whole of what the component does, and says it the same way up whatever the symbol
+    // is rotated to - which a shape cannot do, since two shapes that are mirror images become each
+    // other at 180 degrees. It was drawn as a length of wire until now, with this text floating
+    // beside it at one of four hand-placed offsets.
+    | NbitSpreader 1 -> "Spread"
+    | NbitSpreader n -> $"Spread.1→{n}"
     | _ -> ""
 
 
@@ -617,7 +617,10 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | Demux2 ->( 2  , 2, 3.*gS ,  2.*gS) 
     | Demux4 -> ( 2  , 4, 8. * gS ,  2.*gS) 
     | Demux8 -> ( 2  , 8, 16.*gS ,  2.*gS) 
-    | BusSelection (a, b) -> (  1 , 1, gS/2.,  2.*gS) 
+    // exactly as thin as the line it used to be drawn as: a bus select sits in the middle of
+    // wiring laid out around a half-square-high symbol, and growing it walks it into its
+    // neighbours on every sheet that has one
+    | BusSelection (a, b) -> (  1 , 1, gS/2.,  2.*gS)
     | BusCompare _ | BusCompare1 _ -> ( 1 , 1, gS ,  2.*gS) 
     | DFF -> (  1 , 1, 2.5*gS, 2.5*gS) 
     | DFFE -> ( 2  , 1, 2.5*gS  , 2.5*gS) 
@@ -632,7 +635,9 @@ let getComponentProperties (compType:ComponentType) (label: string)=
     | RAM1 (a) | AsyncRAM1 a -> ( 3 , 1, 4.*gS  , 5.*gS) 
     | NbitsXor (n, _) | NbitsOr (n) |NbitsAnd (n) -> (  2 , 1, 4.*gS  , 4.*gS) 
     | NbitsNot (n)  -> (  1 , 1, 3.*gS  , 4.*gS) 
-    | NbitSpreader (n) -> (1, 1, 2.*gS, 2.*gS)
+    // the footprint of a Register, which is also one in and one out with a name for each: this is
+    // a component rarely enough used to be worth spelling out rather than compressing
+    | NbitSpreader _ -> (1, 1, 2.*gS, 4.*gS)
     | NbitsAdder (n) -> (  3 , 2, 3.*gS  , 4.*gS)
     |NbitsAdderNoCin (n) -> (  2 , 2, 3.*gS  , 4.*gS)
     | NbitsAdderNoCout (n)-> (  3 , 1, 3.*gS  , 4.*gS)

--- a/src/Renderer/DrawBlock/SymbolView.fs
+++ b/src/Renderer/DrawBlock/SymbolView.fs
@@ -269,27 +269,27 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
         
         addText posNew text "middle" "bold" Constants.mergeSplitTextSize
 
-    let busSelectLine msb lsb  =
-        let text = 
-            match msb = lsb  with
-            | true -> sprintf $"({lsb})"
-            | false -> sprintf $"({msb}:{lsb})"
-        let pos, align = 
-            let rotate' = 
-                if not transform.flipped then 
+    /// The bit range a bus select passes, drawn outside its body. The body is small on purpose -
+    /// it sits in the middle of wiring laid out around it - and rotated it is thinner than any
+    /// range, so the range goes beside it rather than in it, and stays the right way up.
+    let busSelectLine nBits lsb =
+        let pos, align =
+            let rotate' =
+                if not transform.flipped then
                     transform.Rotation
                 else
-                    match transform.Rotation with 
+                    match transform.Rotation with
                     | Degree90 -> Degree270 | Degree270 -> Degree90 | r -> r
+            // clear of whichever edge of the body it is put beside, by a couple of pixels
             match rotate' with
-            | Degree0 -> {X=w/2.; Y= h/2. + 7.}, "middle"
-            | Degree180 -> {X=w/2.; Y= -8.}, "middle"
-            | Degree270 -> {X= 4.; Y=h/2. - 7.}, "end"
-            | Degree90 -> {X= 5.+ w/2.; Y=h/2. }, "start"
-        addText pos text align "bold" Constants.busSelectTextSize
+            | Degree0 -> {X=w/2.; Y= h + 2.}, "middle"
+            | Degree180 -> {X=w/2.; Y= -14.}, "middle"
+            | Degree270 -> {X= -2.; Y=h/2. - 7.}, "end"
+            | Degree90 -> {X= w + 2.; Y=h/2. - 7.}, "start"
+        addText pos (busSelectTitle nBits lsb) align "bold" Constants.busSelectTextSize
 
 
-    let clockTxtPos = 
+    let clockTxtPos =
         match transform.Rotation, transform.flipped with
         | Degree0, false -> {X = 17.; Y = H - 13.}
         | Degree180, true -> {X = 17.; Y = 2.}
@@ -314,8 +314,6 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             //    [|{X=W/5.;Y=0};{X=0;Y=H/2.};{X=W/5.;Y=H};{X=W;Y=H};{X=W;Y=0}|]
             | Constant1 _ -> 
                 [|{X=W;Y=H/2.};{X=W/2.;Y=H/2.};{X=0;Y=H};{X=0;Y=0};{X=W/2.;Y=H/2.}|]
-            | IOLabel ->
-                [|{X=0.;Y=H/2.};{X=W;Y=H/2.}|]
             | Viewer _ ->
                 [|{X=W/5.;Y=0};{X=0;Y=H/2.};{X=W/5.;Y=H};{X=W;Y=H};{X=W;Y=0}|]
             | NotConnected ->
@@ -330,8 +328,6 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                 [|{X=0;Y=0.3*W};{X=0;Y=H-0.3*W};{X=W;Y=H};{X=W;Y=0}|]
             | Mux2 | Mux4 | Mux8 -> 
                 [|{X=0;Y=0};{X=0;Y=H};{X=W;Y=H-0.3*W};{X=W;Y=0.3*W}|]
-            | BusSelection _ -> 
-                [|{X=0;Y=H/2.}; {X=W;Y=H/2.}|]
             | BusCompare _ |BusCompare1 _-> 
                 [|{X=0;Y=0};{X=0;Y=H};{X=W*0.6;Y=H};{X=W*0.8;Y=H*0.7};{X=W;Y=H*0.7};{X=W;Y =H*0.3};{X=W*0.8;Y=H*0.3};{X=W*0.6;Y=0}|]
             | Not ->
@@ -344,9 +340,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                 [|{X=0;Y=H-13.};{X=8.;Y=H-7.};{X=0;Y=H-1.};{X=0;Y=0};{X=W;Y=0};{X=W;Y=H};{X=0;Y=H}|]
             | Custom x when symbol.IsClocked = true -> 
                 [|{X=0;Y=H-13.};{X=8.;Y=H-7.};{X=0;Y=H-1.};{X=0;Y=0};{X=W;Y=0};{X=W;Y=H};{X=0;Y=H}|]
-            | NbitSpreader _ ->
-                [|{X=0;Y=H/2.};{X=W*0.4;Y=H/2.};{X=W*0.4;Y=H};{X=W*0.4;Y=0.};{X=W*0.4;Y=H/2.};{X=W;Y=H/2.}|]
-            | _ -> 
+            | _ ->
                 [|{X=0;Y=0};{X=0;Y=H};{X=W;Y=H};{X=W;Y=0}|]
         rotatePoints originalPoints {X=W/2.;Y=H/2.} transform
         |> toString 
@@ -365,14 +359,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
             | Degree90 | Degree270 -> Array.map (fun pos -> pos + {X=12.;Y=0}) textPoints
             | Degree180 -> Array.map (fun pos -> pos + {X=0;Y= +5.}) textPoints
             | _ -> textPoints
-        let NbitSpreaderTextPos =
-            let textPoints = rotatePoints [|{X=W/4.;Y=H/2.+2.};{X=W*0.7;Y=H/2.+4.}|] {X=W/2.;Y=H/2.} transform
-            match transform.Rotation with
-            | Degree90 -> Array.map (fun pos -> pos + {X=13.;Y=(-5.0)}) textPoints
-            | Degree180 -> Array.map (fun pos -> pos + {X=0;Y= +8.}) textPoints
-            | Degree270 -> Array.map (fun pos -> pos + {X=18.;Y=(-5.0)}) textPoints
-            | _ -> textPoints
-        let rotate1 pos = 
+        let rotate1 pos =
             match rotatePoints [|pos|] {X=W/2.;Y=H/2.} transform with 
             | [|pos'|]-> pos' 
             | _ -> failwithf "What? Can't happen"
@@ -421,18 +408,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                 | true -> []
             | None -> []
             
-        | NbitSpreader n -> 
-            //let lo = 1
-            //let msb = hi + lo - 1
-            //let midb = lo
-            //let midt = lo - 1
-            let values = [(-1,0);((n-1),0)]
-            List.fold (fun og i ->
-                og @ mergeSplitLine 
-                        NbitSpreaderTextPos[i] 
-                        (fst values[i]) 
-                        (snd values[i])) [] [0..1]
-        | SplitWire mid -> 
+        | SplitWire mid ->
             let msb, mid' = match symbol.InWidth0 with | Some n -> n - 1, mid | _ -> -100, -50
             let midb = mid'
             let midt = mid'-1
@@ -459,10 +435,10 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
                         og @ mergeSplitNLine comp.Type PortType.Output pos (fst value) (snd value)) [] (Array.toList outputTextPoints)outputValues
             outputEls @ inputEls
             
-        | DFF | DFFE | Register _ |RegisterE _ | ROM1 _ |RAM1 _ | AsyncRAM1 _ | Counter _ | CounterNoEnable _ | CounterNoLoad _ | CounterNoEnableLoad _  -> 
+        | DFF | DFFE | Register _ |RegisterE _ | ROM1 _ |RAM1 _ | AsyncRAM1 _ | Counter _ | CounterNoEnable _ | CounterNoLoad _ | CounterNoEnableLoad _  ->
             (addText clockTxtPos " clk" "middle" "normal" "12px")
-        | BusSelection(nBits,lsb) ->           
-            busSelectLine (lsb + nBits - 1) lsb
+        | BusSelection (nBits, lsb) ->
+            busSelectLine nBits lsb
         | Constant1 (_, _, dialogVal) -> 
             let align, yOffset, xOffset= 
                 match transform.flipped, transform.Rotation with
@@ -491,10 +467,7 @@ let drawComponent (symbol:Symbol) (theme:ThemeType) =
     let outlineColour, strokeWidth =
         match comp.Type with
         | SplitWire _ | MergeWires -> outlineColor colour, "4.0"
-        | NbitSpreader _ -> outlineColor colour, "4.0"
-        | IOLabel -> outlineColor colour, "4.0"
         | NotConnected -> outlineColor colour, "4.0"
-        | BusSelection _ -> outlineColor colour, "4.0"
         | _ -> "black", "1.0"
 
 

--- a/src/Renderer/Simulator/CanvasStateAnalyser.fs
+++ b/src/Renderer/Simulator/CanvasStateAnalyser.fs
@@ -82,7 +82,7 @@ let portNames (componentType:ComponentType)  = //(input port names, output port 
     | Demux4 -> (["DATA"; "SEL"],["0"; "1";"2"; "3";])
     | Demux8 -> (["DATA"; "SEL"],["0"; "1"; "2" ; "3" ; "4" ; "5" ; "6" ; "7"])
     | NbitsXor _ | NbitsAnd _ | NbitsOr _ -> (["P"; "Q"], ["OUT"])
-    | NbitsNot _ -> (["IN"],["OUT"])
+    | NbitsNot _ | NbitSpreader _ -> (["IN"],["OUT"])
     | Shift _ -> (["IN" ; "SHIFT"],["OUT"])
     | Custom x -> (List.map fst x.InputLabels), (List.map fst x.OutputLabels)
     | _ -> ([],[])

--- a/src/Renderer/Simulator/SimGraphTypes.fs
+++ b/src/Renderer/Simulator/SimGraphTypes.fs
@@ -115,7 +115,7 @@ let errMsg (errType: SimulationErrorType) =
         sprintf "%A port appears to have a port number: %d" correctType portNum
     | LabelConnect ->
         sprintf
-            "You can't connect two Wire Labels with a wire. Delete the connecting wire. If you want to join two bus labels \
+            "You can't connect two Net Labels with a wire. Delete the connecting wire. If you want to join two net labels \
                      you need only give them the same name - then they will form a single net."
     | LabelDuplicate (ioType, compLabel) ->
         sprintf "Two %s components cannot have the same label: %s." ioType compLabel

--- a/src/Renderer/UI/CatalogueView.fs
+++ b/src/Renderer/UI/CatalogueView.fs
@@ -30,6 +30,8 @@ open TopMenuView
 open MenuHelpers
 open SheetCreator
 open ParameterTypes
+open Optics
+open Optics.Operators
 
 NearleyBindings.importGrammar
 NearleyBindings.importFix
@@ -38,34 +40,79 @@ NearleyBindings.importParser
 module Constants =
     let maxGateInputs = 19
     let maxSplitMergeBranches = 19
+    /// The size a library component is carried at before its sheet has been read - see GhostBox.
+    let ghostBoxW = 100.
+    let ghostBoxH = 60.
+    /// The colour the draw block gives a symbol dragged on top of another. A carried component
+    /// that would land on one is drawn in it, and for the same reason: it cannot be dropped there.
+    let ghostErrorColour = "Red"
 
 let menuItem styles label onClick =
     Menu.Item.li
         [ Menu.Item.IsActive false; Menu.Item.Props [ OnClick onClick; Style styles ] ]
         [ str label ]
 
-/// Where on the sheet a pointer release landed, if it landed on the canvas at all. Releasing
-/// anywhere else - over the catalogue, the menu bar, outside the window - places nothing, which
-/// is what lets a drag be abandoned by dropping it nowhere.
-let private dropPosOnCanvas (ev: Browser.Types.PointerEvent) (model: Model) : XYPos option =
+/// Where on the sheet a point on the screen is, if it is over the canvas at all. A gesture that
+/// ends anywhere else - over the catalogue, the menu bar, outside the window - is over no position
+/// on the sheet and places nothing, which is what lets a drag be abandoned by dropping it nowhere.
+///
+/// This is the conversion the canvas applies to its own mouse events - SheetDisplay.getDrawBlockPos
+/// - except that the scroll is read from the canvas rather than from the sheet model. The model's
+/// copy of it is refreshed by Sheet.update, and a catalogue drag sends the sheet nothing, so during
+/// one it can be as old as the last thing done to the sheet: after opening a project and going
+/// straight to the catalogue it still holds the scroll the sheet was created with.
+let private sheetPosOfCursor (cursor: XYPos) (sheet: SheetT.Model) : XYPos option =
     match Browser.Dom.document.getElementById "Canvas" with
     | null -> None
     | canvas ->
         let box = canvas.getBoundingClientRect ()
-        match ev.clientX >= box.left && ev.clientX <= box.right
-              && ev.clientY >= box.top && ev.clientY <= box.bottom with
+        match cursor.X >= box.left && cursor.X <= box.right
+              && cursor.Y >= box.top && cursor.Y <= box.bottom with
         | false -> None
-        // The conversion the canvas applies to its own mouse events, so a drop lands under the
-        // pointer however the sheet happens to be scrolled or zoomed.
-        | true -> Some (SheetDisplay.getDrawBlockPos ev getHeaderHeight model.Sheet)
+        | true ->
+            Some {
+                X = (cursor.X + canvas.scrollLeft) / sheet.Zoom
+                Y = (cursor.Y - getHeaderHeight + canvas.scrollTop) / sheet.Zoom
+            }
+
+/// The space a carried component would take up on the sheet if it were dropped at `sheetPos`.
+///
+/// For a symbol this is the box of the symbol that would be created there, worked out by creating
+/// it: a component's size depends on its ports and on the text in it, so anything else here would
+/// be a second, disagreeing, opinion of how big it is.
+let private ghostBoundingBox (model: Model) (ghost: DragGhost) (sheetPos: XYPos) : BoundingBox =
+    match ghost with
+    | GhostSymbol compType ->
+        Symbol.createNewSymbol (tryGetLoadedComponents model) sheetPos compType "" model.Sheet.Wire.Symbol.Theme
+        |> Symbol.getSymbolBoundingBox
+    | GhostBox _ ->
+        {
+            TopLeft = { X = sheetPos.X - Constants.ghostBoxW / 2.; Y = sheetPos.Y - Constants.ghostBoxH / 2. }
+            W = Constants.ghostBoxW
+            H = Constants.ghostBoxH
+        }
+
+/// Whether a component carried to this point would land on top of one already on the sheet.
+///
+/// The sheet refuses to place a component over another, so a drag that would do it is shown as
+/// refused - the ghost turns red - and releasing it does nothing at all.
+let private ghostOverlaps (model: Model) (ghost: DragGhost) (cursor: XYPos) : bool =
+    match sheetPosOfCursor cursor model.Sheet with
+    | None -> false
+    | Some sheetPos ->
+        let box = ghostBoundingBox model ghost sheetPos
+        model.Sheet.BoundingBoxes
+        |> Map.exists (fun _ symbolBox -> DrawHelpers.boxesIntersect symbolBox box)
 
 /// A catalogue item that places a component. `place` is what the item does when it is asked for -
 /// create the component, or open the popup that will - and it runs when the gesture ends.
 ///
 /// Click and drag are one gesture here: a click is a drag that ended somewhere other than the
-/// canvas, and both end in the same call to `place`. Both are driven from pointer events rather
-/// than a click handler because the capture taken on press retargets the click to this item even
-/// when the release was over the canvas, so an OnClick would fire a second time for every drop.
+/// canvas, and both end in the same call to `place`. The exception is a drag released over a
+/// component already on the sheet, which is refused and calls nothing. Both are driven from pointer
+/// events rather than a click handler because the capture taken on press retargets the click to
+/// this item even when the release was over the canvas, so an OnClick would fire a second time for
+/// every drop.
 let private placementItem styles (ghost: DragGhost) label (place: unit -> unit) (model: Model) dispatch =
     /// Whether this item is the one being carried, marked on the element by its own press and
     /// unmarked when that press ends.
@@ -100,12 +147,21 @@ let private placementItem styles (ghost: DragGhost) label (place: unit -> unit) 
             OnPointerUp (fun ev ->
                 if carryingThis ev then
                     setCarrying ev false
-                    // Released over the canvas, the component goes where it was dropped; released
-                    // anywhere else, this was a click, and it follows the cursor as it always has.
-                    match dropPosOnCanvas ev model with
-                    | Some pos -> dispatch (DropDragPlacement pos)
-                    | None -> dispatch EndDragPlacement
-                    place ())
+                    let cursor = { X = ev.clientX; Y = ev.clientY }
+                    match ghostOverlaps model ghost cursor with
+                    // The release the red ghost is warning about. Nothing happens at all: `place`
+                    // is not called, so a component that asks a popup for its parameters does not
+                    // ask for a placement that is not going to happen. The popup belongs to a
+                    // placement that succeeds.
+                    | true -> dispatch EndDragPlacement
+                    | false ->
+                        // Released over free canvas the component goes where it was dropped;
+                        // released off the canvas this was a click, and the component follows the
+                        // cursor as it always has.
+                        match sheetPosOfCursor cursor model.Sheet with
+                        | Some pos -> dispatch (DropDragPlacement pos)
+                        | None -> dispatch EndDragPlacement
+                        place ())
             // A gesture the system takes away - a touch turning into a scroll, the window losing
             // the pointer - places nothing, exactly as a release off the canvas does.
             OnPointerCancel (fun ev ->
@@ -418,6 +474,108 @@ let private createIOPopup hasInt typeStr compType (model:Model) dispatch =
                 getText dialogData
                 |> (fun s -> s = "" || not (String.startsWithLetter s))
             (getInt dialogData < 1) || notGoodLabel
+    dialogPopup title body buttonText buttonAction isDisabled [] dispatch
+
+
+/// The nets on this sheet that already have a name. A net IS its name - every net label carrying
+/// it is the same net - so the names, and not the components carrying them, are what a new label
+/// has to choose between.
+let private netLabelNames (model: Model) : string list =
+    model.Sheet.Wire.Symbol.Symbols
+    |> Map.toList
+    |> List.choose (fun (_, sym) ->
+        match sym.Component.Type with
+        | IOLabel -> Some sym.Component.Label
+        | _ -> None)
+    |> List.distinct
+    |> List.sort
+
+/// The name a label would carry if the text in the box were accepted. Comparing anything against
+/// what was typed rather than against this would let "data" through as a new net beside DATA.
+let private typedNetName (model: Model) : string =
+    MenuHelpers.formatLabelFromType IOLabel (getText model.PopupDialogData)
+
+/// What is wrong with the name in the box, if anything - the message to show, and the reason the
+/// Add button is dead.
+///
+/// A name that an existing net already has is refused rather than quietly joined: joining is what
+/// the pills are for, and a name that collided by accident would otherwise make two nets that were
+/// never meant to be one into a single net, silently and some way from where the user was looking.
+let private newNetProblem (model: Model) : string option =
+    match getText model.PopupDialogData with
+    | "" -> None
+    | typed when not (String.startsWithLetter typed) -> Some "Name must start with a letter"
+    | _ ->
+        let name = typedNetName model
+        match List.contains name (netLabelNames model) with
+        | true -> Some $"{name} is already a net on this sheet - join it above instead"
+        | false -> None
+
+/// Placing a net label.
+///
+/// A net label is a name rather than a component that happens to have one, and the thing a user
+/// wants to do with it is nearly always join a net that already exists. So the nets on the sheet
+/// come first, as pills: clicking one places a label on that net and is the whole of the gesture.
+/// The box below is for the other case, a net that does not exist yet, and refuses any name that
+/// does.
+let private createNetLabelPopup (model: Model) dispatch =
+    let title = "Add net label"
+    /// Place one net label carrying this name and close the popup - what both the pills and the
+    /// button do, and the only thing this dialog exists to do.
+    ///
+    /// The model is the one the popup was opened with rather than the one it is drawn with, because
+    /// that is where a drop position lives: opened by a drop, the label goes where it was dropped.
+    let placeNetLabel (name: string) =
+        createComponent IOLabel (MenuHelpers.formatLabelFromType IOLabel name) None model dispatch
+        dispatch ClosePopup
+    let body =
+        fun (model': Model) ->
+            let netPill (name: string) =
+                Tag.tag [
+                    Tag.Color IsInfo
+                    Tag.Props [
+                        // one of a list of siblings, so React is told which is which
+                        Key name
+                        Style [Cursor "pointer"]
+                        OnClick (fun _ -> placeNetLabel name) ]
+                ] [ str name ]
+            let nets = netLabelNames model'
+            let problem = newNetProblem model'
+            div [] [
+                match nets with
+                | [] -> null
+                | names ->
+                    div [Style [MarginBottom "10px"]] [
+                        str "Join a net on this sheet:"
+                        Tag.list [Tag.List.Props [Style [MarginTop "6px"]]] (List.map netPill names)
+                    ]
+                str (match nets with [] -> "Name the net:" | _ -> "Or name a new net:")
+                Input.text [
+                    Input.Props [AutoFocus true; SpellCheck false]
+                    Input.Placeholder "Net name"
+                    Input.OnChange (JSHelpers.getTextEventValue >> Some >> SetPopupDialogText >> dispatch)
+                ]
+                match problem with
+                | None -> null
+                | Some message -> span [Style [FontStyle "Italic"; Color "Red"]] [str message]
+                hr [Style [MarginTop "12px"; MarginBottom "8px"]]
+                div [Style [FontSize "0.9em"]] [
+                    str "In a digital schematic a set of connected wires is called a net."
+                    br []
+                    str "Every net label with the same name is one net, so a signal can be picked \
+                         up anywhere on the sheet with no wire drawn to it."
+                    br []
+                    str "Use net labels instead of a wire that would cross the sheet, and for high \
+                         fan-out: drive the net once, then join it at each input it feeds."
+                    br []
+                    str "Exactly one label in a net may be driven; the rest drive inputs."
+                ]
+            ]
+    let buttonText = "Add"
+    let buttonAction = fun (model': Model) -> placeNetLabel (getText model'.PopupDialogData)
+    let isDisabled =
+        fun (model': Model) ->
+            getText model'.PopupDialogData = "" || (newNetProblem model').IsSome
     dialogPopup title body buttonText buttonAction isDisabled [] dispatch
 
 
@@ -1165,28 +1323,37 @@ let private makeMenuGroupWithTip styles  title tip menuList =
 ///
 /// Nothing is added to any model. The symbol is built, drawn and discarded on each mouse move,
 /// which is what lets the popup still stand in front of the component being created.
+///
+/// Carried over a component already on the sheet it is drawn red, because there it cannot be
+/// dropped - see ghostOverlaps.
 let viewDragGhost (model: Model) : ReactElement =
     match model.DragPlacement with
     | None | Some (DroppedAt _) -> null
     | Some (Dragging (ghost, cursor)) ->
         let theme = model.Sheet.Wire.Symbol.Theme
         let zoom = model.Sheet.Zoom
+        let overlapping = ghostOverlaps model ghost cursor
         /// Room around the symbol for what the drawing puts outside its own box - port labels
         /// above all - so that the ghost is not clipped by the svg holding it.
         let pad = 40.
         let drawing, w, h =
             match ghost with
             | GhostSymbol compType ->
-                let sym = Symbol.createNewSymbol (tryGetLoadedComponents model) {X = 0.; Y = 0.} compType "" theme
+                let placed = Symbol.createNewSymbol (tryGetLoadedComponents model) {X = 0.; Y = 0.} compType "" theme
+                let sym =
+                    match overlapping with
+                    | true -> placed |> Optic.set (SymbolT.appearance_ >-> SymbolT.colour_) Constants.ghostErrorColour
+                    | false -> placed
                 SymbolView.drawComponent sym theme, sym.Component.W, sym.Component.H
             | GhostBox name ->
                 // A library component's ports are not known until its sheet is read, and reading
                 // it means going to disk - that belongs at placement, not on a mouse-down. So it
                 // is carried as a named box, and takes its true shape once it is placed.
-                let w, h = 100., 60.
+                let w, h = Constants.ghostBoxW, Constants.ghostBoxH
+                let fill = if overlapping then Constants.ghostErrorColour else "lightgray"
                 [ rect [
                     SVGAttr.Width w; SVGAttr.Height h; SVGAttr.Rx 5.
-                    SVGAttr.Fill "lightgray"; SVGAttr.Stroke "black"; SVGAttr.StrokeWidth 1. ] []
+                    SVGAttr.Fill fill; SVGAttr.Stroke "black"; SVGAttr.StrokeWidth 1. ] []
                   text [
                     SVGAttr.X (w / 2.); SVGAttr.Y (h / 2.)
                     SVGAttr.TextAnchor "middle"
@@ -1273,10 +1440,11 @@ let viewCatalogue model dispatch =
                           catTip1 "Constant" (Constant1 (1, 0I, "0")) (fun  _ -> dispatchAsFunc (createConstantPopup)) "Define a one or more bit constant value of specified width, \
                                                                                             e.g. 0 or 1, to drive an input. Values can be written \
                                                                                             in hex, decimal, or binary."
-                          catTip1 "Wire Label" (IOLabel) (fun  _ -> dispatchAsFunc (createIOPopup false "label" (fun _ -> IOLabel))) "Labels with the same name connect \
-                                                                                                                         together wires within a sheet. Each set of labels \
-                                                                                                                         muts have exactly one driving input. \
-                                                                                                                         A label can also be used to terminate an unused output"
+                          catTip1 "Net Label" (IOLabel) (fun  _ -> dispatchAsFunc createNetLabelPopup) "Every net label with the same name is one net, \
+                                                                                                                         connected within a sheet without wires: use them for \
+                                                                                                                         long connections and high fan-out. Each net must have \
+                                                                                                                         exactly one driving input. A net label can also be used \
+                                                                                                                         to terminate an unused output"
                           catTip1 "Not Connected" (NotConnected) (fun  _ -> dispatchAsFunc (createComponent (NotConnected) "" None)) "Not connected component to terminate unused output."]                          
                     makeMenuGroup
                         "Buses"

--- a/src/Renderer/UI/MainView.fs
+++ b/src/Renderer/UI/MainView.fs
@@ -169,8 +169,7 @@ let private  viewRightTab canvasState model dispatch =
         div [ Style [Width "90%"; MarginLeft "5%"; MarginTop "15px" ; Height "calc(100%-100px)"] ] [
             Heading.h4 [] [ str "Catalogue" ]
             div [ Style [ MarginBottom "15px" ; Height "100%"; OverflowY OverflowOptions.Auto] ] 
-                [ str "Drag a component onto the diagram, or click it and then click where it should \
-                       go. Hover on components for details." ]
+                [ str "Drag components to sheet, or click and click to drop. Hover for details." ]
             CatalogueView.viewCatalogue model dispatch
         ]
         

--- a/src/Renderer/UI/SelectedComponentView.fs
+++ b/src/Renderer/UI/SelectedComponentView.fs
@@ -127,7 +127,7 @@ let componentTypeName (ct: ComponentType) : string =
     | Input1 _ | Input _ -> "Input"
     | Output _ -> "Output"
     | Viewer _ -> "Viewer"
-    | IOLabel -> "Wire label"
+    | IOLabel -> "Net label"
     | NotConnected -> "Not connected"
     | Constant1 _ | Constant _ -> "Constant"
     | BusSelection _ -> "Bus selection"
@@ -857,12 +857,13 @@ let private describeComponent (comp:Component) model : ReactElement list =
                number > 0. The input range selected for output is displayed in brackets on the \
                symbol." ]
     | IOLabel ->
-        [ str "Labels with the same name connect wires. Each label has input on left and output on \
-               right. No output connection is required from a set of labels. Since a set represents \
-               one wire of bus, exactly one input connection is required. Labels can be used:"
+        [ str "Net labels with the same name are one net. Each label has input on left and output \
+               on right. No output connection is required from a net. Since a net represents one \
+               wire or bus, exactly one input connection is required. Net labels can be used:"
           br []
           str "To name wires and document designs."; br []
-          str "To join inputs and outputs without wires."; br []
+          str "To join inputs and outputs without wires, in place of a long connection or one \
+               driving many inputs."; br []
           str "To prevent an unused output from giving an error." ]
     | MergeWires ->
         [str "Merge two busses of width n and m into a single bus of width n+m. The bit numbers of \

--- a/src/Renderer/UI/TopMenuView.fs
+++ b/src/Renderer/UI/TopMenuView.fs
@@ -367,7 +367,7 @@ let showDemoProjects model dispatch (demosInfo : (string * int * int) list) =
                             ]
                         | "registerFile" ->
                             div [] [
-                                str "regx16x8 file from EEP1 demo using wire labels to simplify wiring"
+                                str "regx16x8 file from EEP1 demo using net labels to simplify wiring"
                             ]
                         | "adder (4-bit)" ->
                             div [] [

--- a/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
+++ b/src/Renderer/UI/WaveSim/WaveSimHelpers.fs
@@ -70,7 +70,7 @@ let getCompDetails fs wave =
         | Output _ -> "Output", true
         | Constant1 _ -> "What? can't happen", true
         | Viewer _ -> "Viewer", true
-        | IOLabel-> "Wire Label", true
+        | IOLabel-> "Net Label", true
         | NotConnected -> "What? can't happen", true
         | Not ->
             let gateType = $"{fc.FType}".ToUpper()


### PR DESCRIPTION
Two commits, both about saying plainly on the canvas what a component is and what it is about to do.

## Refuse a drop onto an occupied space, and make the wire label a net label

A drag carried over a component already on the sheet cannot be dropped there — the sheet has always refused it — but the drag said nothing until the release, which then quietly turned into a follow-the-cursor placement. The carried ghost is now drawn in the same red the draw block gives a symbol dragged onto another, and the release does nothing at all.

The drop position was also being taken from the sheet model's copy of the canvas scroll, which a catalogue drag never touches; straight after opening a project it still held the scroll the sheet was created with. It is now read off the canvas.

A wire label is a name, not a component that happens to have one, so it is called a Net Label, and its dialog leads with the nets already on the sheet as pills. The rename follows through everywhere it is user-visible.

## Draw the spreader, the bus select and the net label as bodies

Three symbols were drawn as lengths of wire: line segments stroked 4px in a dark grey, with whatever they had to say floating beside them at one of four hand-placed offsets, one per rotation. None could be clicked as a body, none filled when selected, and a shape cannot say which way round it is — two shapes that are mirror images become each other at 180°. All three are combinational, so all three now take the combinational colour.

- **Spreader** — rarely used, so it can afford to spell itself out: a Register's footprint, `IN`/`OUT` on its ports, and a legend of `Spread` over `1→N`.
- **Bus select** — cannot afford that room. It sits in the middle of wiring laid out around a half-square-high symbol, and rotated it is 15px wide, thinner than any bit range. So it keeps exactly the size it has always been, the range stays outside where the four rotations already place it correctly, and only the thick line becomes a thin rectangle.
- **Net label** — the name stays outside where it can be moved to fit. Only its line becomes a rectangle, which is the point: a selected rectangle fills green where a selected line could only change colour.

## Testing

`CI=true npm run test` — 248/248. Two new tests pin the invariants that would otherwise break silently: that a bus select stays small and holds no text whatever range it selects, and that the spreader keeps a named port on each side.

Checked in the running app on the `3cpu` demo sheets: the spreader and both net labels on `shift2`, and — the case that drove the bus select design — a 90°-rotated bus select on `shift`, which draws as a 15×60 vertical box with its range beside it, horizontal and unclipped.

One thing not verified by eye: an **unrotated** bus select's range sits 2.5px lower than before, to clear the box's bottom edge rather than a line's. Same arithmetic as the rotated case that was checked, but worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrtH9pqGeFYGSpFLViwFv6
